### PR TITLE
Add markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The repo consists of two sections: SAS Global and SAS Study-specific standard co
 </br>**Study-specific** - are intended to be copied to and live within a particular study (or protocol) area. It is expected they may need some modifications from study to study, and thus it is anticipated
 they'll be used by one side only (production or validation).
 
+## Documentation
+- [Global Macros Documentation](/man/global/)
+- [Study-specific Macros Documentation](/man/study_specific/)
+
 ## 1. List of the SAS Codes with Short Descriptions
 ### 1.1. Global standard code
 | Type          | Name       | Description                                                                                                                                                                                                                                       |

--- a/man/global/autoexec.md
+++ b/man/global/autoexec.md
@@ -1,0 +1,116 @@
+# autoexec.sas
+
+## Overview
+The `autoexec.sas` file is a system initialization script that sets up the environment for SAS program execution. It establishes global variables, paths, and options based on the operating system, and configures the programming environment for Atorus's standard directory structure.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 19FEB2021
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Operating Systems Supported:
+  - Windows (WIN)
+  - Sun Solaris (SUN 4, SUN 64)
+  - Linux (LIN X64)
+- No macro dependencies
+
+## Parameters
+None - This is an initialization script that runs automatically.
+
+## Return Values/Output
+Creates the following global variables:
+- **`__root`**: Root directory path for projects
+  - Windows: `F:\projects`
+  - Unix/Linux: `/sambaShare/projects`
+- **`II`**: Operating system-specific directory separator
+  - Windows: `\`
+  - Unix/Linux: `/`
+- **`__sponsor_level`**: Flag indicating sponsor-level directory structure (Y/N)
+- **`__prod_qc_separation`**: Flag indicating production/QC separation (Y/N)
+
+Sets the following SAS options:
+- `minoperator`: Enables macro "in" operator
+- `mindelimiter=","`: Sets delimiter for macro "in" operator
+- `mautosource`: Enables autocall macro facility
+- `sasautos`: Adds global macro library to autocall path
+- `validvarname=any`: Allows any valid variable names
+
+## Processing Details
+1. Environment initialization:
+   - Enables required SAS options
+   - Declares global variables
+   - Sets default values
+
+2. Operating system detection:
+   - Identifies system type using `&sysscp`
+   - Sets appropriate root path
+   - Sets directory separator
+
+3. Global macro setup:
+   - Configures autocall macro facility
+   - Sets path to global macro library
+   - Enables flexible variable naming
+
+## Examples
+```sas
+/* The file is executed automatically when placed in the SAS executable directory */
+/* Manual execution if needed */
+%include "[path_to_file]/autoexec.sas";
+
+/* Example of resulting environment setup */
+%put &=__root;      /* F:\projects or /sambaShare/projects */
+%put &=II;          /* \ or / */
+%put &=__sponsor_level;     /* Y */
+%put &=__prod_qc_separation;  /* Y */
+
+------------------------------------------------------------------------------------------------------------------
+/* !!! ALMOST ALWAYS THE AUTOEXEC.SAS FILE THAT RESIDES IN THE SAME DIRECTORY AS SAS.EXE SHOULD CONTAIN AN INCLUDE STATEMENT REFERENCING THIS AUTOEXEC.SAS FILE, SO NO FURTHER INCLUDES ARE NEEDED IN OTHER PROGRAMS */
+------------------------------------------------------------------------------------------------------------------
+```
+
+## Common Issues and Solutions
+1. **Unsupported Operating System**
+   - Error: "operating system [system] is not defined"
+   - Solution: Add system-specific settings for new OS
+
+2. **Incorrect Root Path**
+   - Issue: Programs unable to find project files
+   - Solution: Verify and update `__root` path for environment
+
+3. **Missing Global Macros**
+   - Issue: Unable to find utility macros
+   - Solution: Verify path in `sasautos` option
+
+## Notes and Limitations
+1. File placement:
+   - Should be placed in same directory as sas.exe
+   - Will be executed automatically at SAS startup
+
+2. Environment configuration:
+   - Designed for specific directory structure
+   - Assumes standard project organization
+   - Supports both Windows and Unix-like systems
+
+3. Global settings:
+   - Sets organization-wide standards
+   - Affects all subsequent program execution
+   - Cannot be easily overridden
+
+4. Macro library:
+   - Assumes utility macros in `[root]/utils/func`
+   - Uses standard SAS autocall facility
+   - Preserves existing autocall paths
+
+## Related Files
+- Global utility macros in `[root]/utils/func`
+- Project-specific setup files
+- SAS configuration files
+
+## Change Log
+### Version 1.0 (19FEB2021)
+- Initial release
+- Basic environment setup
+- Windows and Unix support
+- Standard directory structure configuration 

--- a/man/global/xcdtc2dt.md
+++ b/man/global/xcdtc2dt.md
@@ -1,0 +1,84 @@
+# %xcdtc2dt - Convert ISO 8601 Date/Time Character Variables to SAS Date/Time Values
+
+## Overview
+The `%xcdtc2dt` macro converts character ISO 8601 formatted date/time variables (--DTC) into SAS analysis date (-DT), time (-TM), and datetime (-DTM) variables. Additionally, it can create a relative day variable (-DY) when a reference date is provided.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 19FEB2021
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No other macro dependencies
+- Input must be in ISO 8601 format (YYYY-MM-DDThh:mm:ss)
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| dtcdate | Yes | - | Name of the input --DTC variable in ISO 8601 format |
+| prefix | No | a | Prefix for the output analysis variables (-DT, -TM, -DTM, -DY) |
+| refdate | No | - | Numeric reference date for calculating relative days |
+
+## Return Values/Output
+The macro creates the following variables (where 'prefix' is the specified prefix):
+- **prefixDT**: SAS date value
+- **prefixTM**: SAS time value (only if time component is present)
+- **prefixDTM**: SAS datetime value (only if time component is present)
+- **prefixDY**: Relative day number (only if refdate is specified)
+
+## Processing Details
+1. Input Validation:
+   - Checks if required parameter (dtcdate) is provided
+   - Validates length of input date string
+
+2. Date/Time Processing:
+   - For dates without time (length 10): converts to SAS date
+   - For dates with time (length 16 or 19): converts to SAS datetime and splits into date and time components
+
+3. Relative Day Calculation:
+   - If reference date is provided, calculates days between dates
+   - Uses formula: DY = date - refdate + (date >= refdate)
+
+## Examples
+
+### Basic Usage - Date Only
+```sas
+%xcdtc2dt(aestdtc, prefix=ast);
+```
+
+### Usage with Reference Date
+```sas
+%xcdtc2dt(aestdtc, prefix=ast, refdate=trtsdt);
+```
+
+### Advanced Usage with Custom Prefix
+```sas
+%xcdtc2dt(
+    dtcdate=visitdtc,
+    prefix=vst,
+    refdate=studystdt
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Invalid date format | Ensure input date is in ISO 8601 format (YYYY-MM-DD) |
+| Missing relative days | Check if both input date and reference date are non-missing |
+| Partial dates | Only the date portion will be converted, time variables will not be created |
+
+## Notes and Limitations
+- Input must be in ISO 8601 format
+- Handles both partial (date only) and complete (date and time) timestamps
+- Time component must be complete if present (partial times are treated as date-only)
+- Relative day calculation accounts for same-day events (adds 1 for dates >= reference)
+
+## Related Macros
+- xcdtcdy.sas - For relative day calculations
+- Other date/time handling macros in the global library
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 19FEB2021 | Atorus Research | Initial version | 

--- a/man/global/xcdtc2dt.md
+++ b/man/global/xcdtc2dt.md
@@ -76,7 +76,7 @@ The macro creates the following variables (where 'prefix' is the specified prefi
 
 ## See Also
 - [`%xcdtcdy`](/man/global/xcdtcdy.md): For relative day calculations
-- [`%xudt2dtc`](/man/global/xudt2dtc.md): Convert SAS dates to ISO 8601 format
+- [`%xuepoch`](/man/global/xuepoch.md): Derives the EPOCH variable for SDTM datasets
 - [`%xuvisit`](/man/global/xuvisit.md): Visit and timing derivations
 
 ## Change Log

--- a/man/global/xcdtc2dt.md
+++ b/man/global/xcdtc2dt.md
@@ -74,9 +74,10 @@ The macro creates the following variables (where 'prefix' is the specified prefi
 - Time component must be complete if present (partial times are treated as date-only)
 - Relative day calculation accounts for same-day events (adds 1 for dates >= reference)
 
-## Related Macros
-- xcdtcdy.sas - For relative day calculations
-- Other date/time handling macros in the global library
+## See Also
+- [`%xcdtcdy`](/man/global/xcdtcdy.md): For relative day calculations
+- [`%xudt2dtc`](/man/global/xudt2dtc.md): Convert SAS dates to ISO 8601 format
+- [`%xuvisit`](/man/global/xuvisit.md): Visit and timing derivations
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xcdtcdy.md
+++ b/man/global/xcdtcdy.md
@@ -76,9 +76,10 @@ run;
 - Positive study days include the reference date
 - Does not handle partial dates
 
-## Related Macros
-- xcdtc2dt.sas - For converting ISO dates to SAS dates/times
-- Other date handling macros in the global library
+## See Also
+- [`%xcdtc2dt`](/man/global/xcdtc2dt.md): For converting ISO dates to SAS dates/times
+- [`%xudt2dtc`](/man/global/xudt2dtc.md): Convert SAS dates to ISO 8601 format
+- [`%xuvisit`](/man/global/xuvisit.md): Visit and timing derivations
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xcdtcdy.md
+++ b/man/global/xcdtcdy.md
@@ -1,7 +1,7 @@
 # %xcdtcdy - Calculate Study Day from ISO 8601 Dates
 
 ## Overview
-The `%xcdtcdy` macro calculates the study day (--DY) variable from two SDTM character date variables in ISO 8601 format (--DTC). This is commonly used in clinical trials to calculate the number of days between a reference date (usually study start) and another event date.
+The `%xcdtcdy` macro calculates the study day (--DY) variable from two SDTM character date variables in ISO 8601 format (--DTC). This is commonly used in clinical trials to calculate the number of days between a reference date (usually first study drug exposure) and another event date.
 
 ## Version Information
 - **Version**: 1.0
@@ -78,7 +78,7 @@ run;
 
 ## See Also
 - [`%xcdtc2dt`](/man/global/xcdtc2dt.md): For converting ISO dates to SAS dates/times
-- [`%xudt2dtc`](/man/global/xudt2dtc.md): Convert SAS dates to ISO 8601 format
+- [`%xuepoch`](/man/global/xuepoch.md): Derives the EPOCH variable for SDTM datasets
 - [`%xuvisit`](/man/global/xuvisit.md): Visit and timing derivations
 
 ## Change Log

--- a/man/global/xcdtcdy.md
+++ b/man/global/xcdtcdy.md
@@ -1,0 +1,86 @@
+# %xcdtcdy - Calculate Study Day from ISO 8601 Dates
+
+## Overview
+The `%xcdtcdy` macro calculates the study day (--DY) variable from two SDTM character date variables in ISO 8601 format (--DTC). This is commonly used in clinical trials to calculate the number of days between a reference date (usually study start) and another event date.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 19FEB2021
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- Input dates must be in ISO 8601 format (YYYY-MM-DD)
+- No other macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| dtcdate | Yes | - | Name of the character --DTC variable to calculate --DY for |
+| refdate | Yes | - | Name of the reference character date variable |
+
+## Return Values/Output
+The macro creates:
+- A numeric --DY variable with the same prefix as the input dtcdate variable
+  (e.g., if dtcdate=AESTDTC, creates AESTDY)
+- Error messages in the log for invalid date formats or missing parameters
+
+## Processing Details
+1. Input Validation:
+   - Checks if both required parameters are provided
+   - Validates that dates don't contain invalid characters (only 'T' is allowed)
+   - Ensures both dates have at least 10 characters (full date portion)
+
+2. Date Processing:
+   - Extracts the first 10 characters (date portion) from both dates
+   - Converts ISO 8601 dates to SAS dates using e8601da. format
+   - Calculates study day using the formula: DY = date - refdate + (date >= refdate)
+
+3. Error Handling:
+   - Outputs error messages for missing parameters
+   - Outputs error messages for invalid date characters
+   - Skips processing if dates are incomplete
+
+## Examples
+
+### Basic Usage
+```sas
+%xcdtcdy(exstdtc, rfstdtc);
+```
+
+### Lab Data Example
+```sas
+%xcdtcdy(lbdtc, rfstdtc);
+```
+
+### Multiple Calls Example
+```sas
+data ae;
+    set ae;
+    %xcdtcdy(aestdtc, rfstdtc);
+    %xcdtcdy(aeendtc, rfstdtc);
+run;
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Invalid characters in dates | Remove any alphabetic characters except 'T' from the dates |
+| Missing study days | Ensure both dates have at least the date portion (YYYY-MM-DD) |
+| Incorrect day calculation | Verify that the reference date is the correct anchor date |
+
+## Notes and Limitations
+- Only processes dates with at least 10 characters (full date portion)
+- Ignores time components if present
+- Study day 1 is the day of the reference date
+- Positive study days include the reference date
+- Does not handle partial dates
+
+## Related Macros
+- xcdtc2dt.sas - For converting ISO dates to SAS dates/times
+- Other date handling macros in the global library
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 19FEB2021 | Atorus Research | Initial version | 

--- a/man/global/xdalign.md
+++ b/man/global/xdalign.md
@@ -83,8 +83,8 @@ run;
 - Length parameter must include space for both integer and decimal parts
 - Warning will be issued for numbers with more than 5 digits before decimal point
 
-## Related Macros
-- xufmt.sas - For general formatting utilities
+## See Also
+- [`%xufmt`](/man/global/xufmt.md) - For general formatting utilities
 - Other formatting and reporting macros in the global library
 
 ## Change Log

--- a/man/global/xdalign.md
+++ b/man/global/xdalign.md
@@ -1,0 +1,93 @@
+# %xdalign - Decimal Alignment for PDF/RTF Output
+
+## Overview
+The `%xdalign` macro provides proper decimal alignment in PDF or RTF outputs by adding appropriate spacing before numbers. This ensures that decimal points are aligned vertically in tables and reports, improving readability and professional appearance.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 05MAY2021
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No other macro dependencies
+- Requires output to be either PDF or RTF format
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| invar | Yes | - | Input variable name containing the numbers to align |
+| type | No | RTF | Output type (PDF or RTF) |
+| escapechar | No | $ | Escape character used for formatting |
+| len | No | 6 | Total length of the output field, including indentation |
+
+## Return Values/Output
+- Modifies the input variable (`invar`) by adding appropriate spacing for decimal alignment
+- Warning messages in the log for numbers with integer parts longer than 5 digits
+
+## Processing Details
+1. Input Validation:
+   - Checks if required parameters are provided
+   - Validates output type is either PDF or RTF
+   - Verifies length parameter is specified
+
+2. Alignment Processing:
+   - Determines the length of the integer part (before decimal)
+   - Adds appropriate spacing based on output type:
+     - PDF: Uses nbspace formatting
+     - RTF: Uses repeated escape characters
+
+3. Error Handling:
+   - Outputs error for invalid output types
+   - Warns if integer part is longer than 5 digits
+   - Validates required parameters
+
+## Examples
+
+### Basic Usage for RTF
+```sas
+%xdalign(trt_1, type=RTF, len=6);
+```
+
+### PDF Output with Custom Length
+```sas
+%xdalign(
+    invar=mean_val,
+    type=PDF,
+    len=8,
+    escapechar=$
+);
+```
+
+### Multiple Variables in a Data Step
+```sas
+data report;
+    set stats;
+    %xdalign(n_mean, type=PDF, len=8);
+    %xdalign(n_median, type=PDF, len=8);
+    %xdalign(std_dev, type=PDF, len=8);
+run;
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Misaligned decimals | Ensure len parameter accounts for largest possible number |
+| Numbers too large | Increase len parameter or format numbers to have fewer digits |
+| Formatting not appearing | Verify correct escape character is used for your template |
+
+## Notes and Limitations
+- Maximum supported integer length is 5 digits
+- Only supports PDF and RTF output types
+- Assumes decimal numbers (will still work with integers but spacing may be off)
+- Length parameter must include space for both integer and decimal parts
+- Warning will be issued for numbers with more than 5 digits before decimal point
+
+## Related Macros
+- xufmt.sas - For general formatting utilities
+- Other formatting and reporting macros in the global library
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 05MAY2021 | Atorus Research | Initial version | 

--- a/man/global/xtcore.md
+++ b/man/global/xtcore.md
@@ -94,7 +94,7 @@ The `%xtcore` macro adds ADSL core variables to an analysis dataset based on met
 ## See Also
 - [`%xtmeta`](/man/global/xtmeta.md): Processes metadata specifications
 - [`%xtorder`](/man/global/xtorder.md): Orders variables according to metadata
-- [`%xdalign`](/man/global/xdalign.md): Aligns datasets with metadata specifications
+- [`%kutitles`](/man/study_specific/kutitles.md): Title and footnote management
 
 ## Change Log
 ### Version 1.0 (14JUL2022)

--- a/man/global/xtcore.md
+++ b/man/global/xtcore.md
@@ -1,0 +1,104 @@
+# %xtcore
+
+## Overview
+The `%xtcore` macro adds ADSL core variables to an analysis dataset based on metadata specifications. It identifies core variables from the metadata, handles potential variable name conflicts, and ensures consistent subject-level information across analysis datasets.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 14JUL2022
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Datasets:
+  - ADSL dataset in ADAM library
+  - Parent analysis dataset
+- Required Files:
+  - ADaM specification metadata file (default: `ADAM_spec_Variables.csv`)
+
+## Parameters
+- **inds** (required): Name of the parent dataset to add ADSL core variables to.
+- **outds** (optional): Name of the output dataset. Default: value of `inds`.
+- **filename** (optional): Name of the metadata specification file. Default: `ADAM_spec_Variables.csv`.
+- **filepath** (optional): Path to the metadata specification file. Default: `[project path]/final/specs`.
+- **debug** (optional): Flag determining whether to retain temporary datasets. Default: N.
+
+## Return Values/Output
+- Creates a dataset containing:
+  - All variables from the parent dataset (excluding duplicated core variables)
+  - Core variables from ADSL as specified in metadata
+- Creates global macro variable:
+  - `core_vars`: Space-separated list of core variables from ADSL
+- Log messages for processing status and any errors
+
+## Processing Details
+1. Parameter validation:
+   - Checks for required parameters
+   - Verifies metadata file existence
+   - Validates parameter values
+
+2. Metadata processing:
+   - Imports metadata specification file
+   - Identifies ADSL core variables (where core="Y")
+   - Creates global variable list
+   - Identifies overlapping variables between parent and ADSL
+
+3. Data merging:
+   - Sorts datasets by USUBJID
+   - Removes duplicate core variables from parent dataset
+   - Merges parent dataset with ADSL core variables
+   - Retains only matched subjects
+
+## Examples
+```sas
+/* Basic usage - add core variables to ADLB */
+%xtcore(adlb);
+
+/* Specify custom output dataset */
+%xtcore(adae, outds=adae_core);
+
+/* Use custom metadata file */
+%xtcore(adtte, 
+        filename=study_spec_Variables.csv,
+        filepath=/path/to/specs);
+
+/* Keep temporary datasets for debugging */
+%xtcore(adsl, debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Missing Metadata File**
+   - Error: "input [filename] file was not found in [filepath]"
+   - Solution: Verify metadata file exists and path is correct
+
+2. **Missing ADSL Dataset**
+   - Issue: Unable to merge core variables
+   - Solution: Ensure ADSL exists in ADAM library
+
+3. **Duplicate Variables**
+   - Issue: Core variables already exist in parent dataset
+   - Solution: Macro automatically handles by using ADSL versions
+
+## Notes and Limitations
+1. The macro assumes:
+   - ADSL exists in the ADAM library
+   - Metadata file follows standard structure with required columns:
+     - dataset
+     - variable
+     - core
+     - order
+2. Core variables from parent dataset are replaced with ADSL versions
+3. Only records with matching USUBJID in both datasets are retained
+4. STUDYID and USUBJID are always preserved from parent dataset
+
+## Related Macros
+- `%xtmeta`: Processes metadata specifications
+- `%xtorder`: Orders variables according to metadata
+- `%xdalign`: Aligns datasets with metadata specifications
+
+## Change Log
+### Version 1.0 (14JUL2022)
+- Initial release
+- Basic core variable merging functionality
+- Automatic handling of duplicate variables
+- Global variable list creation 

--- a/man/global/xtcore.md
+++ b/man/global/xtcore.md
@@ -91,10 +91,10 @@ The `%xtcore` macro adds ADSL core variables to an analysis dataset based on met
 3. Only records with matching USUBJID in both datasets are retained
 4. STUDYID and USUBJID are always preserved from parent dataset
 
-## Related Macros
-- `%xtmeta`: Processes metadata specifications
-- `%xtorder`: Orders variables according to metadata
-- `%xdalign`: Aligns datasets with metadata specifications
+## See Also
+- [`%xtmeta`](/man/global/xtmeta.md): Processes metadata specifications
+- [`%xtorder`](/man/global/xtorder.md): Orders variables according to metadata
+- [`%xdalign`](/man/global/xdalign.md): Aligns datasets with metadata specifications
 
 ## Change Log
 ### Version 1.0 (14JUL2022)

--- a/man/global/xtmeta.md
+++ b/man/global/xtmeta.md
@@ -1,0 +1,117 @@
+# %xtmeta
+
+## Overview
+The `%xtmeta` macro creates a zero-record dataset based on metadata specifications and generates a global macro variable containing the dataset's variable list. It supports both SDTM and ADaM datasets, automatically determining the appropriate metadata source and handling variable attributes according to specifications.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 20JUL2022
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Files:
+  - SDTM or ADaM specification metadata file (CSV format)
+  - For SDTM: `SDTM_spec_Variables.csv`
+  - For ADaM: `ADAM_spec_Variables.csv`
+- No macro dependencies
+
+## Parameters
+- **dsname** (required): Name of the dataset to look for in the metadata file.
+- **filename** (optional): Name of the CSV metadata file. If not specified, automatically determined based on dataset name:
+  - SDTM for 2-character domains, SUPP--, RELREC, or AP-- datasets
+  - ADaM for all other datasets
+- **filepath** (optional): Path to the metadata file. Default: `[project path]/final/specs`.
+- **qc** (optional): Flag to set all character variable lengths to 200. Default: N.
+- **debug** (optional): Flag to retain temporary datasets. Default: N.
+
+## Return Values/Output
+- Creates a zero-record dataset named `EMPTY_[dsname]` containing:
+  - All variables specified in metadata
+  - Variable attributes (labels, lengths, formats)
+  - No observations
+- Creates a global macro variable `[dsname]KEEPSTRING` containing:
+  - Space-separated list of variables in metadata order
+- Log messages for processing status and any errors
+
+## Processing Details
+1. Parameter validation:
+   - Checks for required parameters
+   - Determines appropriate metadata file
+   - Verifies file existence
+
+2. Metadata processing:
+   - Imports metadata specification
+   - Filters for specified dataset
+   - Sorts variables by specified order
+   - Validates variable lengths
+
+3. Variable attribute handling:
+   - Maps metadata data types to SAS types
+   - Sets variable lengths (standard or QC mode)
+   - Assigns labels and formats
+   - Creates keepstring variable list
+
+## Examples
+```sas
+/* Basic usage - create empty ADSL structure */
+%xtmeta(ADSL);
+
+/* Create SDTM DM structure with QC lengths */
+%xtmeta(DM, qc=Y);
+
+/* Use custom metadata file */
+%xtmeta(ADAE, 
+        filename=study_spec_Variables.csv,
+        filepath=/path/to/specs);
+
+/* Keep temporary datasets for debugging */
+%xtmeta(ADLB, debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Missing Metadata File**
+   - Error: "input [filename] file was not found in [filepath]"
+   - Solution: Verify metadata file exists and path is correct
+
+2. **Dataset Not in Metadata**
+   - Error: "[dsname] does not exist in [filename]"
+   - Solution: Verify dataset name and metadata content
+
+3. **Missing Variable Lengths**
+   - Warning: "Length is not filled for [variables]"
+   - Solution: Review metadata and fill in missing lengths
+
+## Notes and Limitations
+1. Metadata file must follow standard structure with required columns:
+   - dataset
+   - variable
+   - order
+   - label
+   - "Data Type"
+   - length
+   - "Use (y)"
+   - format (for ADaM)
+
+2. Supported data types:
+   - Numeric: INTEGER, FLOAT
+   - Character: TEXT, DATETIME, DATE, TIME, etc.
+
+3. Variable length handling:
+   - Default lengths: 8 for numeric, 200 for character if not specified
+   - QC mode forces all character lengths to 200
+   - Numeric lengths always 8
+
+4. Format assignments only processed for ADaM datasets
+
+## Related Macros
+- `%xtcore`: Uses metadata for core variable processing
+- `%xtorder`: Orders variables according to metadata
+- `%xdalign`: Aligns datasets with metadata specifications
+
+## Change Log
+### Version 1.0 (20JUL2022)
+- Initial release
+- Automatic metadata file selection
+- QC mode for character lengths
+- Support for SDTM and ADaM specifications 

--- a/man/global/xtmeta.md
+++ b/man/global/xtmeta.md
@@ -104,10 +104,10 @@ The `%xtmeta` macro creates a zero-record dataset based on metadata specificatio
 
 4. Format assignments only processed for ADaM datasets
 
-## Related Macros
-- `%xtcore`: Uses metadata for core variable processing
-- `%xtorder`: Orders variables according to metadata
-- `%xdalign`: Aligns datasets with metadata specifications
+## See Also
+- [`%xtcore`](/man/global/xtcore.md): Uses metadata for core variable processing
+- [`%xtorder`](/man/global/xtorder.md): Orders variables according to metadata
+- [`%xdalign`](/man/global/xdalign.md): Aligns datasets with metadata specifications
 
 ## Change Log
 ### Version 1.0 (20JUL2022)

--- a/man/global/xtmeta.md
+++ b/man/global/xtmeta.md
@@ -79,8 +79,33 @@ The `%xtmeta` macro creates a zero-record dataset based on metadata specificatio
    - Solution: Verify dataset name and metadata content
 
 3. **Missing Variable Lengths**
-   - Warning: "Length is not filled for [variables]"
+   - Note: "Length is not filled for [variables]"
    - Solution: Review metadata and fill in missing lengths
+
+4. **Unexpected Variable's Value Retain**
+   - Occurs when: set the EMPTY_[dsname] with a non-empty dataset, and do some further data processing in the same datastep
+   - Solution: separate the setting of the data from the postprocessing into two datasteps.
+   </br>Examples:
+   ```sas
+   /* This will cause an issue: */
+   data <dataset_name>;
+      set &empty._domain <rawdata>;
+      <data processing statements>;
+   run;
+
+   /* Correct use: */
+   data <dataset_name>;
+      set &empty_domain. <rawdata>;
+   run;
+
+   data <dataset_name_1>;
+      set <dataset_name>;
+      <data processing statements>;
+   run;
+   ```
+5. **Erroneous assumption the ADaM metadata is being used when it is not**.
+   - Occurs when: used for the "spit" datasets (LBSA, LBPD, LBCHEM, etc.) the macro assumes it is ADaM dataset, because the name exceeds two characters (SUPPXX datasets and RELREC are special cases and are accounted for)
+   - Solution: explicitly specify SDTM metadata file name in corresponding macro parameter.
 
 ## Notes and Limitations
 1. Metadata file must follow standard structure with required columns:
@@ -107,7 +132,7 @@ The `%xtmeta` macro creates a zero-record dataset based on metadata specificatio
 ## See Also
 - [`%xtcore`](/man/global/xtcore.md): Uses metadata for core variable processing
 - [`%xtorder`](/man/global/xtorder.md): Orders variables according to metadata
-- [`%xdalign`](/man/global/xdalign.md): Aligns datasets with metadata specifications
+- [`%kutitles`](/man/study_specific/kutitles.md): Title and footnote management
 
 ## Change Log
 ### Version 1.0 (20JUL2022)

--- a/man/global/xtorder.md
+++ b/man/global/xtorder.md
@@ -98,10 +98,10 @@ The `%xtorder` macro creates a global macro variable containing the sort order f
    - Validity of variable names
    - Duplicate variables in sort order
 
-## Related Macros
-- `%xtmeta`: Creates dataset structure from metadata
-- `%xtcore`: Uses metadata for core variable processing
-- `%xdalign`: Aligns datasets with metadata specifications
+## See Also
+- [`%xtmeta`](/man/global/xtmeta.md): Creates dataset structure from metadata
+- [`%xtcore`](/man/global/xtcore.md): Uses metadata for core variable processing
+- [`%xdalign`](/man/global/xdalign.md): Aligns datasets with metadata specifications
 
 ## Change Log
 ### Version 1.0 (20JUL2022)

--- a/man/global/xtorder.md
+++ b/man/global/xtorder.md
@@ -77,6 +77,10 @@ The `%xtorder` macro creates a global macro variable containing the sort order f
 3. **Missing Key Variables**
    - Issue: Empty SORTSTRING created
    - Solution: Check "Key Variables" column in metadata
+   
+4. **Erroneous assumption the ADaM metadata is being used when it is not**.
+   - Occurs when: used for the "spit" datasets (LBSA, LBPD, LBCHEM, etc.) the macro assumes it is ADaM dataset, because the name exceeds two characters (SUPPXX datasets and RELREC are special cases and are accounted for)
+   - Solution: explicitly specify SDTM metadata file name in corresponding macro parameter.
 
 ## Notes and Limitations
 1. Metadata file must follow standard structure with required columns:

--- a/man/global/xtorder.md
+++ b/man/global/xtorder.md
@@ -1,0 +1,111 @@
+# %xtorder
+
+## Overview
+The `%xtorder` macro creates a global macro variable containing the sort order for a dataset based on metadata specifications. It automatically determines whether to use SDTM or ADaM metadata and extracts the key variables that define the dataset's sort order.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 20JUL2022
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Files:
+  - SDTM or ADaM specification metadata file (CSV format)
+  - For SDTM: `SDTM_spec_Datasets.csv`
+  - For ADaM: `ADAM_spec_Datasets.csv`
+- No macro dependencies
+
+## Parameters
+- **dsname** (required): Name of the dataset to look for in the metadata file.
+- **filename** (optional): Name of the CSV metadata file. If not specified, automatically determined based on dataset name:
+  - SDTM for 2-character domains, SUPP--, RELREC, or AP-- datasets
+  - ADaM for all other datasets
+- **filepath** (optional): Path to the metadata file. Default: `[project path]/final/specs`.
+- **debug** (optional): Flag to retain temporary datasets. Default: N.
+
+## Return Values/Output
+- Creates a global macro variable `[dsname]SORTSTRING` containing:
+  - Space-separated list of key variables defining the dataset's sort order
+  - Extracted from the "Key Variables" column in metadata
+- Log messages for processing status and any errors
+
+## Processing Details
+1. Parameter validation:
+   - Checks for required parameters
+   - Determines appropriate metadata file
+   - Verifies file existence
+
+2. Metadata processing:
+   - Imports metadata specification
+   - Filters for specified dataset
+   - Extracts key variables information
+
+3. Sort string creation:
+   - Processes "Key Variables" column
+   - Converts comma-separated list to space-separated
+   - Creates global macro variable
+
+## Examples
+```sas
+/* Basic usage - get sort order for ADSL */
+%xtorder(ADSL);
+%put &ADSLSORTSTRING;  /* Example output: STUDYID USUBJID */
+
+/* Get sort order for SDTM domain */
+%xtorder(DM);
+%put &DMSORTSTRING;    /* Example output: STUDYID USUBJID */
+
+/* Use custom metadata file */
+%xtorder(ADAE, 
+         filename=study_spec_Datasets.csv,
+         filepath=/path/to/specs);
+
+/* Keep temporary datasets for debugging */
+%xtorder(ADLB, debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Missing Metadata File**
+   - Error: "input [filename] file was not found in [filepath]"
+   - Solution: Verify metadata file exists and path is correct
+
+2. **Dataset Not in Metadata**
+   - Error: "[dsname] does not exist in [filename]"
+   - Solution: Verify dataset name and metadata content
+
+3. **Missing Key Variables**
+   - Issue: Empty SORTSTRING created
+   - Solution: Check "Key Variables" column in metadata
+
+## Notes and Limitations
+1. Metadata file must follow standard structure with required columns:
+   - dataset
+   - "Key Variables"
+
+2. The macro assumes:
+   - Key variables are listed in the correct order
+   - Variables are comma-separated in metadata
+   - Variable names are valid SAS names
+
+3. The resulting sort string:
+   - Has commas replaced with spaces
+   - Contains no leading/trailing spaces
+   - Preserves the order specified in metadata
+
+4. No validation is performed on:
+   - Existence of key variables in dataset
+   - Validity of variable names
+   - Duplicate variables in sort order
+
+## Related Macros
+- `%xtmeta`: Creates dataset structure from metadata
+- `%xtcore`: Uses metadata for core variable processing
+- `%xdalign`: Aligns datasets with metadata specifications
+
+## Change Log
+### Version 1.0 (20JUL2022)
+- Initial release
+- Automatic metadata file selection
+- Support for SDTM and ADaM specifications
+- Basic sort string generation 

--- a/man/global/xucomm.md
+++ b/man/global/xucomm.md
@@ -1,0 +1,103 @@
+# %xucomm - Create SDTM Comments (CO) Domain Records
+
+## Overview
+The `%xucomm` macro creates SDTM Comments (CO) domain records from source datasets. It processes comments from any SDTM domain and creates standardized CO records following CDISC SDTM standards, with proper sequencing and handling of multiple comment lines.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 15JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- Requires the following macros:
+  - xtmeta.sas - For CO domain metadata
+  - xtorder.sas - For sorting specifications
+  - xusplit.sas - For splitting comment text
+- Global macro variable `&domain` must be defined before macro call
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Name of the input dataset containing comments |
+| invar | Yes | - | Name of the input variable containing comment text |
+| idvar | No | domainseq | Name of the ID variable (ignored for DM domain) |
+| qc | No | N | Set to Y if macro is used for QC purposes |
+| debug | No | N | Set to Y to retain temporary datasets |
+
+## Return Values/Output
+Creates a dataset named:
+- `sdtm.domain_comm` if qc=N
+- `qcdomain_comm` if qc=Y
+
+Output dataset contains standard CO domain variables:
+- STUDYID, RDOMAIN, USUBJID
+- IDVAR, IDVARVAL (when applicable)
+- COSEQ
+- COVAL1-COVALn (as needed for long comments)
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Checks for &domain macro variable
+   - Validates IDVAR handling for DM domain
+
+2. Comment Processing:
+   - Splits comments into multiple lines if needed
+   - Creates appropriate number of COVALx variables
+   - Handles both character and numeric ID variables
+
+3. Sequence Generation:
+   - Creates COSEQ within USUBJID
+   - Ensures proper sorting of output records
+   - Removes duplicates
+
+## Examples
+
+### Basic Usage for DM Domain
+```sas
+%let domain = DM;
+%xucomm(dm, dmcomm);
+```
+
+### Usage with ID Variable
+```sas
+%let domain = LB;
+%xucomm(qclb, lbcomm, idvar=lbseq, qc=Y);
+```
+
+### Debug Mode
+```sas
+%let domain = AE;
+%xucomm(
+    inds=ae,
+    invar=aecomm,
+    idvar=aeseq,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing domain variable | Define %let domain=XX before macro call |
+| Duplicate comments | Check input data for duplicates |
+| Missing metadata | Ensure xtmeta macro has CO domain specifications |
+
+## Notes and Limitations
+- Requires pre-defined &domain macro variable
+- DM domain has special handling (no IDVAR/IDVARVAL)
+- Comments are automatically split if they exceed COVALx length
+- Warns if more COVALx variables are needed than specified in metadata
+- QC mode creates separate output dataset with 'qc' prefix
+
+## Related Macros
+- xtmeta.sas - For metadata handling
+- xtorder.sas - For sorting specifications
+- xusplit.sas - For text splitting
+- Other SDTM utility macros
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 15JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xucomm.md
+++ b/man/global/xucomm.md
@@ -91,11 +91,11 @@ Output dataset contains standard CO domain variables:
 - Warns if more COVALx variables are needed than specified in metadata
 - QC mode creates separate output dataset with 'qc' prefix
 
-## Related Macros
-- xtmeta.sas - For metadata handling
-- xtorder.sas - For sorting specifications
-- xusplit.sas - For text splitting
-- Other SDTM utility macros
+## See Also
+- [`%xtmeta`](/man/global/xtmeta.md): For metadata handling
+- [`%xtorder`](/man/global/xtorder.md): For sorting specifications
+- [`%xusplit`](/man/global/xusplit.md): For text splitting
+- [`%xumrgcs`](/man/global/xumrgcs.md): For merging comments with parent domains
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xucomm.md
+++ b/man/global/xucomm.md
@@ -1,7 +1,7 @@
 # %xucomm - Create SDTM Comments (CO) Domain Records
 
 ## Overview
-The `%xucomm` macro creates SDTM Comments (CO) domain records from source datasets. It processes comments from any SDTM domain and creates standardized CO records following CDISC SDTM standards, with proper sequencing and handling of multiple comment lines.
+The `%xucomm` macro creates SDTM Comments (CO) domain records from source datasets. It processes comments from any SDTM domain and creates standardized CO records following CDISC SDTM standards, with proper handling of multiple comment lines.
 
 ## Version Information
 - **Version**: 1.0

--- a/man/global/xucont.md
+++ b/man/global/xucont.md
@@ -81,10 +81,10 @@ Generates CONTENTS procedure output for each dataset:
 - Output format follows PROC CONTENTS standards
 - Error messages identify specific dataset issues
 
-## Related Macros
-- Dataset inspection utilities
-- Metadata management tools
-- Quality control macros
+## See Also
+- [`%xuload`](/man/global/xuload.md): Dataset loading utility
+- [`%xusave`](/man/global/xusave.md): Dataset saving utility
+- [`%xuct`](/man/global/xuct.md): Controlled terminology validation
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xucont.md
+++ b/man/global/xucont.md
@@ -1,0 +1,92 @@
+# %xucont - Dataset Contents Procedure Utility
+
+## Overview
+The `%xucont` macro executes the CONTENTS procedure on one or more datasets, providing detailed information about dataset attributes, variables, and metadata. It supports multiple datasets and customizable CONTENTS procedure options while handling error checking for dataset existence.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 12AUG2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Space-separated list of input dataset names |
+| sourcelib | Yes | - | Name of the input library |
+| contopts | No | varnum | Options for the CONTENTS procedure |
+
+## Return Values/Output
+Generates CONTENTS procedure output for each dataset:
+- Dataset attributes
+- Variable information
+- Index information
+- Sort information
+- Additional metadata based on specified options
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Checks for non-empty values
+   - Validates dataset existence
+
+2. Dataset Processing:
+   - Parses multiple dataset names
+   - Verifies each dataset exists
+   - Handles errors individually
+
+3. Output Generation:
+   - Executes CONTENTS procedure
+   - Applies specified options
+   - Generates separate output for each dataset
+
+## Examples
+
+### Basic Usage
+```sas
+%xucont(dm, sdtm);
+```
+
+### Multiple Datasets
+```sas
+%xucont(dm suppdm ae suppae, sdtm);
+```
+
+### Custom Options
+```sas
+%xucont(
+    inds=adsl adae,
+    sourcelib=adam,
+    contopts=varnum short
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Dataset not found | Verify dataset exists in library |
+| Invalid library | Check library assignment |
+| Invalid options | Review PROC CONTENTS documentation |
+
+## Notes and Limitations
+- Processes multiple datasets sequentially
+- Continues processing after dataset errors
+- Default option is VARNUM for variable ordering
+- Reports errors for missing datasets
+- Each dataset processed independently
+- No temporary datasets created
+- Output format follows PROC CONTENTS standards
+- Error messages identify specific dataset issues
+
+## Related Macros
+- Dataset inspection utilities
+- Metadata management tools
+- Quality control macros
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 12AUG2022 | Atorus Research | Initial version | 

--- a/man/global/xuct.md
+++ b/man/global/xuct.md
@@ -90,10 +90,10 @@ The `%xuct` macro validates variable values against controlled terminology defin
 3. Non-printable characters in codelist values are detected and reported but not automatically corrected.
 4. The macro processes one variable/codelist combination at a time.
 
-## Related Macros
-- `%xufmt`: Creates SAS formats from codelists
-- `%xuloadcsv`: Imports and processes CSV files
-- `%xuload`: Loads datasets with format handling
+## See Also
+- [`%xufmt`](/man/global/xufmt.md): Creates SAS formats from codelists
+- [`%xuloadcsv`](/man/global/xuloadcsv.md): Imports and processes CSV files
+- [`%xuload`](/man/global/xuload.md): Loads datasets with format handling
 
 ## Change Log
 ### Version 1.0 (12AUG2022)

--- a/man/global/xuct.md
+++ b/man/global/xuct.md
@@ -1,0 +1,103 @@
+# %xuct
+
+## Overview
+The `%xuct` macro validates variable values against controlled terminology defined in both the study specifications and CDISC SDTM Controlled Terminology. It checks if variables contain only the values specified in the Codelists tab of the specification and optionally verifies compliance with CDISC SDTM Controlled Terminology.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 12AUG2022
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Files:
+  - Codelists metadata file (default: `SDTM_spec_Codelists.csv`)
+  - CDISC SDTM Controlled Terminology dataset (`_ct.sas7bdat`) in the misc library
+  - If `_ct.sas7bdat` is missing, CDISC SDTM Controlled Terminology CSV file (default: `SDTM Terminology.csv`)
+
+## Parameters
+- **inds** (required): Name of the input dataset to check.
+- **invar** (required): Name of the variable in the input dataset to be checked.
+- **codelist** (required): Codelist name as specified in the ID column of the codelists metadata file.
+- **subset** (optional): Logical condition to be used in the where clause when a variable may have multiple codelists. Default: `1=1` (all observations).
+- **filename** (optional): Codelists metadata file name. Default: `SDTM_spec_Codelists.csv`.
+- **filepath** (optional): Path to the codelists metadata file. Default: `[project path]/final/specs`.
+- **ctfile** (optional): CDISC SDTM Controlled Terminology file name (CSV format). Default: `SDTM Terminology.csv`.
+- **ctpath** (optional): Path to CDISC SDTM Controlled Terminology file. Default: `[project path]/final/raw/dict`.
+- **checkct** (optional): Flag determining whether values should be checked for compliance with CDISC SDTM CT. Default: Y.
+- **debug** (optional): Flag determining whether to delete temporary datasets. Default: N.
+
+## Return Values/Output
+- Log messages indicating:
+  - Values not found in the specification's Codelists tab
+  - Values not compliant with CDISC SDTM Controlled Terminology (if checkct=Y)
+  - Non-printable characters found in codelist values
+  - Error messages for missing or invalid parameters
+- Creates `_ct.sas7bdat` in the misc library if not already present
+
+## Processing Details
+1. Parameter validation:
+   - Checks for required parameters
+   - Verifies existence of codelist metadata file
+   - Checks for CDISC CT dataset or source file
+2. Codelist processing:
+   - Handles domain-specific codelists (e.g., EX.UNIT, LB.UNIT)
+   - Imports and processes codelist metadata
+   - Validates data types for codelist values
+3. Data validation:
+   - Checks for non-printable characters in codelist values
+   - Merges specification codelists with input data
+   - If checkct=Y, validates against CDISC CT
+4. Error handling:
+   - Reports missing or invalid parameters
+   - Warns about non-compliant values
+   - Identifies non-printable characters
+
+## Examples
+```sas
+/* Basic usage - check CMCAT variable against CMCAT codelist */
+%xuct(cm, CMCAT, CMCAT, checkct=N);
+
+/* Check EXDOSU against domain-specific UNIT codelist with CT validation */
+%xuct(ex, EXDOSU, EX.UNIT, checkct=Y);
+
+/* Check LBORRESU with custom subset condition */
+%xuct(lb, LBORRESU, LB.UNIT, subset=%str(LBCAT='CHEMISTRY'), checkct=Y);
+
+/* IMPORTANT: Understanding `checkct` parameter behavior:
+   - When checkct=N: Values are only validated against the Codelists tab in the specification (e.g., SDTM_spec_Codelists.csv)
+   - When checkct=Y: Values are validated against both the Codelists tab AND CDISC controlled terminology
+   - For prefixed codelists (e.g., EX.UNIT), the prefix is removed before CDISC CT validation */
+%xuct(ex, EXDOSU, EX.UNIT, checkct=Y);  /* Will check values against UNIT in CDISC CT */
+```
+
+## Common Issues and Solutions
+1. **Missing Codelist in Specification**
+   - Error: "Codelist ID = [name] was not found in Codelists tab of the spec"
+   - Solution: Verify codelist name and ensure it exists in the specification
+
+2. **Missing CDISC CT Dataset**
+   - Error: "misc._ct data set does not exist"
+   - Solution: Ensure `ctfile` parameter points to valid CDISC CT CSV file
+
+3. **Invalid Data Types**
+   - Error: "Unknown Data Type for [codelist] codelist"
+   - Solution: Use valid data types in specification (text, integer, float, etc.)
+
+## Notes and Limitations
+1. For domain-specific codelists (e.g., units used across multiple domains), the codelist ID must use DOMAIN.CODELIST format (e.g., EX.UNIT, LB.UNIT).
+2. The CDISC CT CSV file must use "$" as the delimiter.
+3. Non-printable characters in codelist values are detected and reported but not automatically corrected.
+4. The macro processes one variable/codelist combination at a time.
+
+## Related Macros
+- `%xufmt`: Creates SAS formats from codelists
+- `%xuloadcsv`: Imports and processes CSV files
+- `%xuload`: Loads datasets with format handling
+
+## Change Log
+### Version 1.0 (12AUG2022)
+- Initial release
+- Basic codelist validation functionality
+- CDISC CT compliance checking
+- Non-printable character detection 

--- a/man/global/xuepoch.md
+++ b/man/global/xuepoch.md
@@ -49,7 +49,7 @@ The `%xuepoch` macro derives the EPOCH variable for SDTM datasets using the Stud
 %xuepoch(lb, lbdtc);
 
 /* Specify custom output dataset */
-%xuepoch(ae, aedtc, outds=ae_with_epoch);
+%xuepoch(ae, aestdtc, outds=ae_with_epoch);
 
 /* Keep temporary datasets for debugging */
 %xuepoch(vs, vsdtc, debug=Y);

--- a/man/global/xuepoch.md
+++ b/man/global/xuepoch.md
@@ -1,0 +1,90 @@
+# %xuepoch
+
+## Overview
+The `%xuepoch` macro derives the EPOCH variable for SDTM datasets using the Study Elements (SE) domain. It determines the study epoch for each record based on the timing of events relative to study milestones defined in SE, handling both complete and partial dates with appropriate comparison logic.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 20JUL2022
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Datasets:
+  - SE domain in SDTM library
+- Required Macros:
+  - `%xuload`: Used to load the SE domain
+
+## Parameters
+- **inds** (required): Name of the input dataset to derive EPOCH for.
+- **dtcdate** (required): Name of the date variable to use for epoch determination.
+- **outds** (optional): Name of the output dataset. Default: value of `inds`.
+- **debug** (optional): Flag determining whether to retain temporary datasets. Default: N.
+
+## Return Values/Output
+- Creates or updates a dataset containing all variables from the input dataset plus:
+  - EPOCH: Character variable containing the derived study epoch
+- When debug=N, temporary variables are dropped from the output
+- Log messages for parameter validation and processing status
+
+## Processing Details
+1. Parameter validation:
+   - Checks for required parameters
+   - Verifies parameter values are not empty
+2. Data processing:
+   - Loads SE domain using `%xuload`
+   - Sorts SE by USUBJID and SESTDTC
+   - Transposes SE to create one record per subject with epoch start dates
+3. Epoch derivation:
+   - Merges input data with transposed SE data
+   - Compares dates using sophisticated logic:
+     - Full datetime comparison for complete datetime values
+     - Date-only comparison when time is not available
+     - Partial date comparison for incomplete dates
+   - Assigns EPOCH based on the most recent epoch start date before the record's date
+
+## Examples
+```sas
+/* Basic usage - derive EPOCH for LB domain using LBDTC */
+%xuepoch(lb, lbdtc);
+
+/* Specify custom output dataset */
+%xuepoch(ae, aedtc, outds=ae_with_epoch);
+
+/* Keep temporary datasets for debugging */
+%xuepoch(vs, vsdtc, debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Missing SE Domain**
+   - Issue: SE domain not found in SDTM library
+   - Solution: Ensure SE domain is present and accessible
+
+2. **Date Comparison Issues**
+   - Issue: Unexpected EPOCH assignments
+   - Solution: Verify date formats and completeness in both input and SE datasets
+
+3. **Missing EPOCH Values**
+   - Issue: Records with no assigned EPOCH
+   - Solution: Check if dates fall within any defined study epochs in SE
+
+## Notes and Limitations
+1. The macro assumes the SE domain follows SDTM standards with required variables USUBJID, SESTDTC, and EPOCH.
+2. Date comparisons handle three scenarios:
+   - Complete datetime values (length=16)
+   - Date-only values (length=10)
+   - Partial dates (length<10)
+3. When comparing dates of different completeness, the comparison uses the length of the less complete date.
+4. The macro preserves all input dataset variables in the output.
+
+## Related Macros
+- `%xuload`: Used to load SDTM datasets
+- `%xuvisit`: Derives VISIT/VISITNUM variables
+- `%xcdtc2dt`: Converts ISO 8601 dates to SAS dates
+
+## Change Log
+### Version 1.0 (20JUL2022)
+- Initial release
+- Basic epoch derivation functionality
+- Handling of complete and partial dates
+- Debug mode implementation 

--- a/man/global/xuepoch.md
+++ b/man/global/xuepoch.md
@@ -77,10 +77,10 @@ The `%xuepoch` macro derives the EPOCH variable for SDTM datasets using the Stud
 3. When comparing dates of different completeness, the comparison uses the length of the less complete date.
 4. The macro preserves all input dataset variables in the output.
 
-## Related Macros
-- `%xuload`: Used to load SDTM datasets
-- `%xuvisit`: Derives VISIT/VISITNUM variables
-- `%xcdtc2dt`: Converts ISO 8601 dates to SAS dates
+## See Also
+- [`%xuload`](/man/global/xuload.md): Used to load SDTM datasets
+- [`%xuvisit`](/man/global/xuvisit.md): Derives VISIT/VISITNUM variables
+- [`%xcdtc2dt`](/man/global/xcdtc2dt.md): Converts ISO 8601 dates to SAS dates
 
 ## Change Log
 ### Version 1.0 (20JUL2022)

--- a/man/global/xufmt.md
+++ b/man/global/xufmt.md
@@ -87,10 +87,10 @@ Creates the following SAS formats for each codelist:
 - Only creates formats for unique mappings
 - Format names are automatically generated from codelist ID
 
-## Related Macros
-- xuct.sas - For controlled terminology validation
-- Other format and codelist handling macros
-- Data standardization macros
+## See Also
+- [`%xuct`](/man/global/xuct.md): For controlled terminology validation
+- [`%xuload`](/man/global/xuload.md): Dataset loading with format handling
+- [`%xuloadcsv`](/man/global/xuloadcsv.md): CSV file loading utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xufmt.md
+++ b/man/global/xufmt.md
@@ -1,0 +1,98 @@
+# %xufmt - Create SAS Formats from Specification Codelists
+
+## Overview
+The `%xufmt` macro creates SAS formats from codelists defined in SDTM or ADaM specifications. It generates bidirectional formats for terms, decoded values, and order numbers, enabling flexible data transformations and labeling.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 13JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- Required files:
+  - SDTM_spec_Codelists.csv or ADaM_spec_Codelists.csv
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| fmt | Yes | - | Space-separated list of codelist names to create formats for |
+| filename | Yes | - | Source file name (SDTM_spec_Codelists.csv or ADaM_spec_Codelists.csv) |
+| filepath | No | [project path]/final/specs | Path to the source file |
+| debug | No | N | Whether to retain temporary datasets (Y/N) |
+
+## Return Values/Output
+Creates the following SAS formats for each codelist:
+- `IDxx` formats where ID is the codelist name and xx is the conversion type:
+  - OT: Order to Term
+  - TO: Term to Order
+  - OD: Order to Decoded value
+  - DO: Decoded value to Order
+  - DT: Decoded value to Term
+  - TD: Term to Decoded value
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Checks source file existence
+   - Validates codelist name lengths (≤ 29 characters)
+
+2. Format Creation:
+   - Imports codelist metadata
+   - Checks for non-printable characters
+   - Creates bidirectional formats for all combinations
+   - Handles numeric and character conversions
+
+3. Quality Control:
+   - Removes duplicate format entries
+   - Validates format uniqueness
+   - Compresses dots in format names
+   - Checks for non-printable characters
+
+## Examples
+
+### Basic Usage - Single Codelist
+```sas
+%xufmt(VSPARAM, ADaM_spec_Codelist.csv);
+```
+
+### Multiple Codelists
+```sas
+%xufmt(RACE SEX, SDTM_spec_Codelist.csv);
+```
+
+### Custom Path with Debug
+```sas
+%xufmt(
+    fmt=SEVERITY,
+    filename=SDTM_spec_Codelists.csv,
+    filepath=/path/to/specs,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Invalid format names | Ensure codelist IDs are ≤ 29 characters |
+| Non-printable characters | Clean source data of special characters |
+| Duplicate mappings | Check codelist for unique term/decoded value pairs |
+
+## Notes and Limitations
+- Maximum codelist name length is 29 characters
+- Dots in codelist names are compressed
+- Non-printable characters cause term exclusion
+- Creates multiple format types per codelist
+- Only creates formats for unique mappings
+- Format names are automatically generated from codelist ID
+
+## Related Macros
+- xuct.sas - For controlled terminology validation
+- Other format and codelist handling macros
+- Data standardization macros
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 13JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xuload.md
+++ b/man/global/xuload.md
@@ -85,10 +85,10 @@ Creates in WORK library:
 - Temporary format search path modification in 'keep' mode
 - Debug mode retains intermediate processing datasets
 
-## Related Macros
-- xufmt.sas - For format creation
-- Other dataset management macros
-- Data standardization utilities
+## See Also
+- [`%xufmt`](/man/global/xufmt.md): For format creation
+- [`%xuloadcsv`](/man/global/xuloadcsv.md): CSV file loading utility
+- [`%xusave`](/man/global/xusave.md): Dataset saving utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xuload.md
+++ b/man/global/xuload.md
@@ -1,0 +1,96 @@
+# %xuload - Dataset Loading and Format Management Utility
+
+## Overview
+The `%xuload` macro loads datasets into the SAS work library while managing formats and informats. It provides flexible control over format handling, dataset sorting, and encoding, with three distinct modes for format processing: smart, keep, and remove.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 13JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No macro dependencies
+- Optional format catalog (.sas7bcat) for 'keep' mode
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Space-separated list of input dataset names |
+| sourcelib | Yes | - | Name of the input library |
+| sortvars | No | - | Variables to sort by |
+| encoding | No | - | Dataset encoding specification |
+| mode | No | smart | Format processing mode (smart/keep/remove) |
+| fmtlib | No | &sourcelib | Library containing format catalogs (required for keep mode) |
+| debug | No | N | Whether to retain temporary datasets (Y/N) |
+
+## Return Values/Output
+Creates in WORK library:
+- Loaded datasets with processed formats/informats
+- Optional sorting applied if specified
+- Log messages for format processing actions
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Validates mode parameter values
+   - Checks dataset existence
+   - Validates format catalog availability for 'keep' mode
+
+2. Format Processing Modes:
+   - **smart**: Removes unexpected formats/informats
+   - **keep**: Preserves formats using specified format catalog
+   - **remove**: Strips all formats/informats
+
+3. Dataset Processing:
+   - Loads datasets with specified encoding
+   - Applies format processing according to mode
+   - Performs optional sorting
+   - Handles multiple datasets sequentially
+
+## Examples
+
+### Basic Usage
+```sas
+%xuload(dm, sdtm, sortvars=usubjid);
+```
+
+### Multiple Datasets with Format Preservation
+```sas
+%xuload(dm ae, crf, encoding=asciiany, mode=keep, fmtlib=crf);
+```
+
+### Remove All Formats
+```sas
+%xuload(
+    inds=adsl adae,
+    sourcelib=adam,
+    mode=remove,
+    sortvars=usubjid
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing format catalog | Verify .sas7bcat exists in fmtlib |
+| Dataset not found | Check sourcelib and dataset names |
+| Invalid formats | Use 'smart' mode to clean formats |
+
+## Notes and Limitations
+- 'smart' mode removes formats not in SASHELP.VFORMAT
+- 'keep' mode requires valid format catalog
+- 'remove' mode strips ALL formats/informats
+- Processes multiple datasets sequentially
+- Temporary format search path modification in 'keep' mode
+- Debug mode retains intermediate processing datasets
+
+## Related Macros
+- xufmt.sas - For format creation
+- Other dataset management macros
+- Data standardization utilities
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 13JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xuloadcsv.md
+++ b/man/global/xuloadcsv.md
@@ -1,0 +1,104 @@
+# %xuloadcsv - CSV File Loading and Consolidation Utility
+
+## Overview
+The `%xuloadcsv` macro loads and combines multiple CSV files into a single SAS dataset. It supports regular expressions for file selection, handles variable naming, and can extract subject IDs and visit information from filenames. This is particularly useful for consolidating clinical data from multiple source files.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 18JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No macro dependencies
+- Requires access to source CSV files
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| filename | Yes | - | Regular expression to filter source files |
+| filepath | No | [project path]/final/raw/external | Path to CSV files |
+| splitchar | No | $ | CSV delimiter character |
+| datarow | No | 2 | First row of data (after headers) |
+| subjid | No | - | Regex to extract subject ID from filename |
+| visit | No | - | Regex to extract visit from filename |
+| outds | No | raw_all | Output dataset name |
+| getnames | No | yes | Whether to use first row as variable names |
+| compress_names | No | Y | Whether to remove spaces from variable names |
+| debug | No | N | Whether to retain temporary datasets |
+
+## Return Values/Output
+Creates a consolidated dataset containing:
+- Combined data from all matching CSV files
+- Optional derived variables:
+  - dataset_no: Sequential number for source file
+  - subjid_derived: Extracted subject ID (if subjid specified)
+  - visit_derived: Extracted visit (if visit specified)
+- Standardized variable lengths across files
+
+## Processing Details
+1. File Selection:
+   - Uses regex to filter files in directory
+   - Excludes Excel files (xlsx, xlt)
+   - Extracts metadata from filenames
+
+2. Variable Processing:
+   - Handles header rows if present
+   - Standardizes variable names
+   - Determines optimal variable lengths
+   - Converts all variables to character initially
+
+3. Data Consolidation:
+   - Imports each file sequentially
+   - Applies consistent variable attributes
+   - Combines data with metadata
+   - Handles missing or empty files
+
+## Examples
+
+### Basic Usage
+```sas
+%xuloadcsv(filename=%str(Clamp), subjid=%str(101-\d{3}), visit=%str(D\d+));
+```
+
+### Exclude Specific Files
+```sas
+%xuloadcsv(filename=%str(^(?!.*(Dummy|PC|PK)).*csv$));
+```
+
+### Custom Settings
+```sas
+%xuloadcsv(
+    filename=%str(LAB.*\.csv),
+    splitchar=",",
+    datarow=3,
+    compress_names=N,
+    outds=combined_labs
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| No files found | Check regex pattern and filepath |
+| Variable name conflicts | Use compress_names=Y or adjust source headers |
+| Misaligned data | Verify datarow setting matches file structure |
+
+## Notes and Limitations
+- All files must share similar structure
+- Initial import treats all variables as character
+- Variable lengths are maximized across all files
+- Regex patterns must follow SAS PRX syntax
+- Excel files are automatically excluded
+- Header handling requires consistent structure
+- Maximum filename length for extracted values is 200
+
+## Related Macros
+- xuload.sas - For loading SAS datasets
+- Other data import utilities
+- File handling macros
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 18JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xuloadcsv.md
+++ b/man/global/xuloadcsv.md
@@ -93,10 +93,10 @@ Creates a consolidated dataset containing:
 - Header handling requires consistent structure
 - Maximum filename length for extracted values is 200
 
-## Related Macros
-- xuload.sas - For loading SAS datasets
-- Other data import utilities
-- File handling macros
+## See Also
+- [`%xuload`](/man/global/xuload.md): For loading SAS datasets
+- [`%xufmt`](/man/global/xufmt.md): Format creation and management
+- [`%xusave`](/man/global/xusave.md): Dataset saving utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xumprint.md
+++ b/man/global/xumprint.md
@@ -1,0 +1,97 @@
+# %xumprint - Log and Output Management Utility
+
+## Overview
+The `%xumprint` macro manages SAS log and listing file handling, providing functionality to save these files to specific directories and reload logs back into SAS sessions. It also enhances log readability by converting certain notes of interest into warnings. The macro acts as a wrapper (like DO-END blocks) and should be called at both the start and end of SAS programs.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 19FEB2021
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- Required macros:
+  - xuprogpath.sas - For creating task and program-related globals
+  - setup.sas - For assigning required libnames and sasautos
+- Required global variables (when route=YES):
+  - __p_name: Program name (created automatically by xuprogpath.sas)
+  - __log_path: Path to log folder (created automatically by xuprogpath.sas)
+  - __lst_path: Path to outputs folder (created automatically by xuprogpath.sas)
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| route | No | NO | Controls file handling mode. YES saves output lst and log files, NO uploads log back to SAS EG |
+
+## Return Values/Output
+- When route=YES:
+  - Creates .log and .lst files in task-specific directories
+  - Cleans macro cache before execution
+  - Sets up program environment
+- When route=NO:
+  - Displays modified log in SAS EG
+  - Converts certain notes to warnings
+  - Restores original SAS options
+
+## Processing Details
+1. Input Validation:
+   - Verifies route parameter is either YES or NO
+   - Checks for required global variables when route=YES
+
+2. When route=YES:
+   - Cleans macro cache (deletes previously resolved macros)
+   - Calls xuprogpath for task/program globals
+   - Redirects output to specified files
+   - Includes setup.sas for environment configuration
+
+3. When route=NO:
+   - Restores default output destinations
+   - Reads and modifies log file content
+   - Enhances log readability by:
+     - Converting NOTE xxx-xxx to NOTE:
+     - Elevating certain notes to warnings
+   - Restores original SAS options
+
+## Examples
+
+### Program Start
+```sas
+%xumprint(route=YES);
+```
+
+### Program End
+```sas
+%xumprint();
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing global variables | Ensure program is saved and xuprogpath.sas is called |
+| Macro cache conflicts | Use route=YES at program start to clean cache |
+| Log file not found | Verify correct path and program name globals |
+
+## Notes and Limitations
+- Program must be saved for route=YES to work
+- Macro cache cleaning only affects standardized prefix macros
+- Log modification only occurs when reading back to SAS EG
+- Specific notes are automatically elevated to warnings:
+  - Uninitialized variables
+  - Invalid operations
+  - Division by zero
+  - Graph legend constraints
+  - Format size issues
+  - Merge statement repeats
+  - Missing value operations
+  - Loading failures
+  - Data type conversions
+
+## Related Macros
+- xuprogpath.sas - Program path management
+- setup.sas - Environment configuration
+- Other logging and output management macros
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 19FEB2021 | Atorus Research | Initial version | 

--- a/man/global/xumprint.md
+++ b/man/global/xumprint.md
@@ -86,8 +86,8 @@ The `%xumprint` macro manages SAS log and listing file handling, providing funct
   - Loading failures
   - Data type conversions
 
-## Related Macros
-- xuprogpath.sas - Program path management
+## See Also
+- [`%xuprogpath`](/man/global/xuprogpath.md) - Program path management
 - setup.sas - Environment configuration
 - Other logging and output management macros
 

--- a/man/global/xumprint.md
+++ b/man/global/xumprint.md
@@ -42,7 +42,7 @@ The `%xumprint` macro manages SAS log and listing file handling, providing funct
    - Cleans macro cache (deletes previously resolved macros)
    - Calls xuprogpath for task/program globals
    - Redirects output to specified files
-   - Includes setup.sas for environment configuration
+   - Includes [`setup.sas`](/man/study_specific/setup.md) for environment configuration
 
 3. When route=NO:
    - Restores default output destinations
@@ -88,7 +88,7 @@ The `%xumprint` macro manages SAS log and listing file handling, providing funct
 
 ## See Also
 - [`%xuprogpath`](/man/global/xuprogpath.md) - Program path management
-- setup.sas - Environment configuration
+- [`setup.sas`](/man/study_specific/setup.md) - For assigning required libnames and sasautos
 - Other logging and output management macros
 
 ## Change Log

--- a/man/global/xumrgcs.md
+++ b/man/global/xumrgcs.md
@@ -85,10 +85,10 @@ The `%xumrgcs` macro merges Supplemental Qualifiers (SUPP--) and Comments (CO) d
 4. For CO merging, a single CO dataset contains comments for all domains.
 5. Output dataset names reflect the types of data merged.
 
-## Related Macros
-- `%xusupp`: Creates supplemental qualifier datasets
-- `%xuload`: Loads SDTM datasets
-- `%xusplit`: Splits datasets by specified criteria
+## See Also
+- [`%xusupp`](/man/global/xusupp.md): Creates supplemental qualifier datasets
+- [`%xuload`](/man/global/xuload.md): Loads SDTM datasets
+- [`%xusplit`](/man/global/xusplit.md): Splits datasets by specified criteria
 
 ## Change Log
 ### Version 1.0 (22AUG2022)

--- a/man/global/xumrgcs.md
+++ b/man/global/xumrgcs.md
@@ -55,8 +55,8 @@ The `%xumrgcs` macro merges Supplemental Qualifiers (SUPP--) and Comments (CO) d
 
 ## Examples
 ```sas
-/* Merge both SUPP and CO for DM and AE domains */
-%xumrgcs(dm ae, sdtm, supp=Y, co=Y);
+/* Merge both SUPP and CO for LB and AE domains */
+%xumrgcs(lb ae, sdtm, supp=Y, co=Y);
 
 /* Merge only SUPP for PR domain */
 %xumrgcs(pr, sdtm, supp=Y, co=N);

--- a/man/global/xumrgcs.md
+++ b/man/global/xumrgcs.md
@@ -1,0 +1,98 @@
+# %xumrgcs
+
+## Overview
+The `%xumrgcs` macro merges Supplemental Qualifiers (SUPP--) and Comments (CO) datasets with their parent SDTM datasets. It handles multiple input datasets, automatically determines identifier variables and their types, and performs appropriate data type conversions for merging.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 22AUG2022
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Datasets:
+  - Parent SDTM dataset(s) in the source library
+  - SUPP-- datasets (if supp=Y)
+  - CO dataset (if co=Y)
+- No macro dependencies
+
+## Parameters
+- **inds** (required): Space-separated list of input dataset names to process.
+- **sourcelib** (required): Name of the library containing input datasets.
+- **supp** (optional): Flag determining whether to merge SUPP-- datasets. Default: Y.
+- **co** (optional): Flag determining whether to merge CO dataset. Default: Y.
+- **debug** (optional): Flag determining whether to retain temporary datasets. Default: N.
+
+## Return Values/Output
+- Creates new datasets with naming convention:
+  - `[dataset]_supp` when only SUPP-- is merged
+  - `[dataset]_co` when only CO is merged
+  - `[dataset]_supp_co` when both are merged
+- Output datasets contain:
+  - All variables from the parent dataset
+  - Transposed supplemental qualifier variables (if supp=Y)
+  - Comment variables (COVALx) for the domain (if co=Y)
+- Log messages for processing status and any errors
+
+## Processing Details
+1. Parameter validation:
+   - Checks for required parameters
+   - Validates Y/N flags
+   - Ensures at least one of supp/co is Y
+2. For each input dataset:
+   - Verifies dataset existence
+   - Gets domain name from dataset
+3. SUPP-- processing (if supp=Y):
+   - Identifies IDVAR and its type
+   - Transposes SUPP-- data by QNAM
+   - Converts IDVARVAL to match parent dataset type
+   - Merges with parent dataset
+4. CO processing (if co=Y):
+   - Filters CO for relevant domain
+   - Identifies IDVAR and its type
+   - Converts IDVARVAL to match parent dataset type
+   - Merges with parent or SUPP-merged dataset
+
+## Examples
+```sas
+/* Merge both SUPP and CO for DM and AE domains */
+%xumrgcs(dm ae, sdtm, supp=Y, co=Y);
+
+/* Merge only SUPP for PR domain */
+%xumrgcs(pr, sdtm, supp=Y, co=N);
+
+/* Merge only CO for multiple domains with debug mode */
+%xumrgcs(ae cm vs, sdtm, supp=N, co=Y, debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Missing Supplemental Dataset**
+   - Error: "SUPP[domain] was not found in [library] library"
+   - Solution: Verify SUPP-- dataset exists for the domain
+
+2. **Missing CO Dataset**
+   - Error: "CO was not found in [library] library"
+   - Solution: Ensure CO dataset exists in the source library
+
+3. **No Comments for Domain**
+   - Warning: "CO has no comments for [domain] domain"
+   - Solution: Verify if comments are expected for the domain
+
+## Notes and Limitations
+1. Both supp and co parameters cannot be N simultaneously.
+2. The macro handles both character and numeric ID variables automatically.
+3. For SUPP-- merging, each domain must have its corresponding SUPP[domain] dataset.
+4. For CO merging, a single CO dataset contains comments for all domains.
+5. Output dataset names reflect the types of data merged.
+
+## Related Macros
+- `%xusupp`: Creates supplemental qualifier datasets
+- `%xuload`: Loads SDTM datasets
+- `%xusplit`: Splits datasets by specified criteria
+
+## Change Log
+### Version 1.0 (22AUG2022)
+- Initial release
+- Support for multiple input datasets
+- Automatic handling of ID variable types
+- Flexible SUPP/CO merging options 

--- a/man/global/xuprogpath.md
+++ b/man/global/xuprogpath.md
@@ -113,7 +113,7 @@ Lst path: C:/Projects/Client/Compound/Protocol/Task/final/sdtm/lst/
 
 ## See Also
 - [`%xumprint`](/man/global/xumprint.md): Calls `%xuprogpath` for program information
-- [`%xucomm`](/man/global/xucomm.md): Uses path information for documentation
+- [`setup.sas`](/man/study_specific/setup.md): Sets up the study global variables and libnames
 - Other setup and initialization macros
 
 ## Change Log

--- a/man/global/xuprogpath.md
+++ b/man/global/xuprogpath.md
@@ -62,7 +62,7 @@ Creates the following global variables:
 
 ## Examples
 ```sas
-/* Basic usage - typically called by setup.sas or %xumprint */
+/* Basic usage - typically called by [`setup.sas`](/man/study_specific/setup.md) or %xumprint */
 %xuprogpath;
 
 /* Example output in log:
@@ -109,7 +109,7 @@ Lst path: C:/Projects/Client/Compound/Protocol/Task/final/sdtm/lst/
    - Optional sponsor level: Client/Compound/Protocol
    - Standard level: Compound/Protocol
 3. Assumes standard folder types (development/final) and program types (sdtm/adam/tlf).
-4. Should be called automatically by `%xumprint` or setup.sas.
+4. Should be called automatically by `%xumprint` or [`setup.sas`](/man/study_specific/setup.md).
 
 ## See Also
 - [`%xumprint`](/man/global/xumprint.md): Calls `%xuprogpath` for program information

--- a/man/global/xuprogpath.md
+++ b/man/global/xuprogpath.md
@@ -111,9 +111,9 @@ Lst path: C:/Projects/Client/Compound/Protocol/Task/final/sdtm/lst/
 3. Assumes standard folder types (development/final) and program types (sdtm/adam/tlf).
 4. Should be called automatically by `%xumprint` or setup.sas.
 
-## Related Macros
-- `%xumprint`: Calls `%xuprogpath` for program information
-- `%xucomm`: Uses path information for documentation
+## See Also
+- [`%xumprint`](/man/global/xumprint.md): Calls `%xuprogpath` for program information
+- [`%xucomm`](/man/global/xucomm.md): Uses path information for documentation
 - Other setup and initialization macros
 
 ## Change Log

--- a/man/global/xuprogpath.md
+++ b/man/global/xuprogpath.md
@@ -1,0 +1,124 @@
+# %xuprogpath
+
+## Overview
+The `%xuprogpath` macro determines the full path of the currently executing SAS program and creates global variables containing task-related information based on Atorus's standard programming environment structure. It parses the program path to extract information about the client, compound, protocol, task, and other organizational elements.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 19FEB2021
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Global Variables:
+  - `_sasprogramfile`: Set by SAS EG to contain the full program path
+  - `__root`: Root directory path (set in autoexec.sas)
+  - `__sponsor_level`: Flag indicating sponsor-level directory structure (Y/N; set in autoexec.sas)
+  - `__prod_qc_separation`: Flag indicating production/QC separation (Y/N; set in autoexec.sas)
+  - `II`: Directory separator character (set in autoexec.sas)
+- No macro dependencies
+
+## Parameters
+None - The macro uses global variables and system information to perform its functions.
+
+## Return Values/Output
+Creates the following global variables:
+- **Path-related**:
+  - `__program_full_path`: Full path to the executing program
+  - `__p_name`: Program name without extension
+  - `__p_path`: Program directory path
+  - `__log_path`: Path for log files
+  - `__lst_path`: Path for list files
+
+- **Organization-related**:
+  - `__clnt`: Client name (if sponsor_level=Y)
+  - `__comp`: Compound name
+  - `__prot`: Protocol name
+  - `__subfolders`: Intermediate folder structure
+  - `__task`: Task name
+  - `__level`: Development level (development/final)
+  - `__side`: Production side (prod/val)
+  - `__type`: Program type (sdtm/adam/tlf)
+
+## Processing Details
+1. Environment check:
+   - Verifies existence of `_sasprogramfile` variable
+   - Validates program path is not empty
+
+2. Path parsing:
+   - Extracts program path relative to root directory
+   - Determines organizational structure based on `__sponsor_level`
+   - Identifies development level (final/development)
+   - Extracts subfolder structure between protocol and task
+
+3. Variable creation:
+   - Sets path-related variables
+   - Determines organizational variables
+   - Creates log and list file paths
+
+4. Logging:
+   - Outputs all created variables to log
+   - Groups information by category (program, task, outputs)
+
+## Examples
+```sas
+/* Basic usage - typically called by setup.sas or %xumprint */
+%xuprogpath;
+
+/* Example output in log:
+******************************************************************************************************
+=== Program being executed === 
+Program executed by: jsmith
+Program full path  : C:/Projects/Client/Compound/Protocol/Task/final/sdtm/program/dm.sas
+Program name       : dm
+Program path       : C:/Projects/Client/Compound/Protocol/Task/final/sdtm/program/
+******************************************************************************************************
+=== Task Information === 
+Client    : Client
+Compound  : Compound
+Protocol  : Protocol
+Subfolders: 
+Task      : Task
+Level     : final
+Side      : prod
+Type      : sdtm
+******************************************************************************************************
+=== Logs and lst outputs path === 
+Log path: C:/Projects/Client/Compound/Protocol/Task/final/sdtm/log/
+Lst path: C:/Projects/Client/Compound/Protocol/Task/final/sdtm/lst/
+******************************************************************************************************
+*/
+```
+
+## Common Issues and Solutions
+1. **Missing Program Path**
+   - Issue: `_sasprogramfile` is empty or not set
+   - Solution: Ensure program is run through SAS EG or proper environment setup
+
+2. **Incorrect Directory Structure**
+   - Issue: Unable to parse organizational elements
+   - Solution: Verify folder structure follows Atorus standards
+
+3. **Missing Global Variables**
+   - Issue: Required global variables not set
+   - Solution: Ensure autoexec.sas properly initializes environment
+
+## Notes and Limitations
+1. Designed specifically for Atorus's standard programming environment structure.
+2. Requires specific directory hierarchy:
+   - Optional sponsor level: Client/Compound/Protocol
+   - Standard level: Compound/Protocol
+3. Assumes standard folder types (development/final) and program types (sdtm/adam/tlf).
+4. Should be called automatically by `%xumprint` or setup.sas.
+
+## Related Macros
+- `%xumprint`: Calls `%xuprogpath` for program information
+- `%xucomm`: Uses path information for documentation
+- Other setup and initialization macros
+
+## Change Log
+### Version 1.0 (19FEB2021)
+- Initial release
+- Basic path parsing functionality
+- Support for sponsor-level directory structures
+- Automatic log/lst path determination 

--- a/man/global/xurnm.md
+++ b/man/global/xurnm.md
@@ -1,0 +1,102 @@
+# %xurnm - Variable Renaming Utility
+
+## Overview
+The `%xurnm` macro provides functionality to rename all variables in a dataset by either adding a prefix or removing characters from the beginning of variable names. It handles special characters in variable names and maintains the dataset structure while performing bulk renaming operations.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 14JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Name of the input dataset |
+| mode | Yes | add | Working mode: 'add' to add prefix, 'remove' to remove characters |
+| prefix | No* | _ | Characters to add before variable names (*Required if mode=add) |
+| rchar | No* | 1 | Number of characters to remove from start of variable names (*Required if mode=remove) |
+| outds | No | &inds | Name of output dataset |
+| debug | No | N | Whether to retain temporary datasets (Y/N) |
+
+## Return Values/Output
+Creates a dataset containing:
+- All variables from input dataset
+- Renamed variables according to specified mode:
+  - add: All variables prefixed with specified characters
+  - remove: Specified number of characters removed from start of names
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Validates mode parameter (add/remove)
+   - Checks conditional requirements:
+     - prefix required for add mode
+     - rchar required for remove mode
+
+2. Variable Processing:
+   - Extracts dataset metadata using PROC CONTENTS
+   - Maintains variable order using VARNUM
+   - Creates rename list handling special characters
+
+3. Renaming Operation:
+   - Handles special characters using VALIDVARNAME syntax
+   - Processes all variables maintaining dataset structure
+   - Creates new dataset with renamed variables
+
+## Examples
+
+### Add Prefix to Variables
+```sas
+%xurnm(ds, mode=add, prefix=PRE_);
+```
+
+### Remove Characters from Variable Names
+```sas
+%xurnm(
+    inds=input_ds,
+    mode=remove,
+    rchar=2,
+    outds=output_ds
+);
+```
+
+### Debug Mode with Custom Output
+```sas
+%xurnm(
+    inds=source,
+    mode=add,
+    prefix=TMP_,
+    outds=renamed,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Invalid variable names | Use valid SAS naming conventions for prefix |
+| Special characters | Macro handles special chars using VALIDVARNAME |
+| Name length exceeded | Ensure final names are ≤32 characters |
+
+## Notes and Limitations
+- Maximum SAS variable name length is 32 characters
+- Handles variables with special characters
+- Preserves variable order from input dataset
+- Debug mode retains temporary datasets for troubleshooting
+- Mode parameter is case-insensitive
+- Cannot selectively rename variables (applies to all)
+- Original dataset structure is preserved
+
+## Related Macros
+- Variable management macros
+- Dataset manipulation utilities
+- Naming convention enforcement tools
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 14JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xurnm.md
+++ b/man/global/xurnm.md
@@ -91,10 +91,10 @@ Creates a dataset containing:
 - Cannot selectively rename variables (applies to all)
 - Original dataset structure is preserved
 
-## Related Macros
-- Variable management macros
-- Dataset manipulation utilities
-- Naming convention enforcement tools
+## See Also
+- [`%xuload`](/man/global/xuload.md): Dataset loading utility
+- [`%xusave`](/man/global/xusave.md): Dataset saving utility
+- [`%xucont`](/man/global/xucont.md): Dataset contents utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xusave.md
+++ b/man/global/xusave.md
@@ -96,10 +96,10 @@ Creates the following files:
 - Output library must be pre-assigned
 - Transport files created in same directory as SAS datasets
 
-## Related Macros
-- Dataset management macros
-- SDTM/ADaM utilities
-- Export and archival tools
+## See Also
+- [`%xuload`](/man/global/xuload.md): Dataset loading utility
+- [`%xuloadcsv`](/man/global/xuloadcsv.md): CSV file loading utility
+- [`%xusplit`](/man/global/xusplit.md): Dataset splitting utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xusave.md
+++ b/man/global/xusave.md
@@ -1,0 +1,107 @@
+# %xusave - Dataset Save and Export Utility
+
+## Overview
+The `%xusave` macro provides functionality to save datasets in both SAS (.sas7bdat) and transport (.xpt) formats while applying dataset modifications such as variable selection, sorting, and labeling. It's particularly useful for finalizing datasets in clinical research environments where standardized outputs are required.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 13JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No macro dependencies
+- Write access to output library location
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Name of the input dataset |
+| outlib | Yes | - | Name of the output library |
+| outds | No | &inds | Name of the output dataset |
+| keepvars | No | - | Space-separated list of variables to keep |
+| sortvars | No | - | Space-separated list of variables to sort by |
+| dslbl | No | - | Label for the dataset |
+| xpt | No | Y | Whether to save transport file (Y/N) |
+| debug | No | N | Whether to retain temporary datasets (Y/N) |
+
+## Return Values/Output
+Creates the following files:
+- SAS dataset (.sas7bdat) in specified output library
+- Transport file (.xpt) in same location if xpt=Y
+- Both outputs include:
+  - Selected variables (if keepvars specified)
+  - Applied sorting (if sortvars specified)
+  - Dataset label (if dslbl specified)
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Checks for non-empty values
+
+2. Dataset Processing:
+   - Creates intermediate working copy
+   - Applies sorting if specified
+   - Selects variables if specified
+   - Applies dataset label if specified
+
+3. File Creation:
+   - Saves SAS dataset (.sas7bdat)
+   - Creates transport file (.xpt) if requested
+   - Cleans up temporary datasets unless in debug mode
+
+## Examples
+
+### Basic Usage
+```sas
+%xusave(dm, sdtm, outds=dm);
+```
+
+### Full Feature Usage
+```sas
+%xusave(
+    inds=ae,
+    outlib=sdtm,
+    outds=ae,
+    keepvars=studyid usubjid aeterm aestdtc,
+    sortvars=usubjid aestdtc,
+    dslbl=Adverse Events,
+    xpt=Y
+);
+```
+
+### Debug Mode
+```sas
+%xusave(
+    inds=vs,
+    outlib=sdtm,
+    keepvars=studyid usubjid visit vsorres,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Write permission errors | Verify access to output location |
+| Invalid variable names | Check keepvars list against dataset |
+| Sort order issues | Ensure sortvars exist in final dataset |
+
+## Notes and Limitations
+- Transport files are automatically lowercase
+- Temporary datasets use macro name prefix
+- Debug mode retains intermediate datasets
+- Sort variables must exist in kept variables
+- Transport files follow SAS V5 format
+- Output library must be pre-assigned
+- Transport files created in same directory as SAS datasets
+
+## Related Macros
+- Dataset management macros
+- SDTM/ADaM utilities
+- Export and archival tools
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 13JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xuseq.md
+++ b/man/global/xuseq.md
@@ -89,10 +89,10 @@ Modifies input dataset to include:
 - Sort variables determine sequence grouping
 - Assumes USUBJID is present in dataset
 
-## Related Macros
-- SDTM/ADaM sequence generation macros
-- Dataset sorting utilities
-- Variable creation tools
+## See Also
+- [`%xuvisit`](/man/global/xuvisit.md): Visit sequence number generation
+- [`%xuload`](/man/global/xuload.md): Dataset loading utility
+- [`%xusave`](/man/global/xusave.md): Dataset saving utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xuseq.md
+++ b/man/global/xuseq.md
@@ -1,0 +1,100 @@
+# %xuseq - Sequence Number Generation Utility
+
+## Overview
+The `%xuseq` macro creates sequence numbers for observations within a dataset, typically used in clinical data standards to generate --SEQ variables. It assigns sequential numbers based on specified sorting criteria, with options for customizing the sequence variable name prefix.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 14JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- Optional global variable:
+  - domain: Default prefix for sequence variable if prefix parameter not specified
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Name of the input dataset |
+| sortvars | Yes | - | Space-separated list of variables to sort by |
+| prefix | No | &domain | Prefix for the sequence variable name |
+| debug | No | N | Whether to retain temporary variables (Y/N) |
+
+## Return Values/Output
+Modifies input dataset to include:
+- New sequence variable named [prefix]SEQ
+- Sequential numbers starting at 1 for each unique combination of sort variables
+- Original dataset structure preserved
+- Temporary variables removed unless debug=Y
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Checks prefix resolution:
+     - Uses specified prefix if provided
+     - Uses &domain value if available and prefix not specified
+     - Errors if neither available
+
+2. Data Processing:
+   - Sorts dataset by specified variables
+   - Creates temporary counter variable
+   - Generates sequence numbers
+   - Assigns values to final sequence variable
+
+3. Cleanup:
+   - Removes temporary variables unless in debug mode
+   - Maintains original dataset structure
+
+## Examples
+
+### Basic Usage with Domain Variable
+```sas
+%let domain = AE;
+%xuseq(ae, usubjid);
+```
+
+### Custom Prefix
+```sas
+%xuseq(
+    inds=adlb,
+    sortvars=usubjid paramcd adt,
+    prefix=a
+);
+```
+
+### Debug Mode
+```sas
+%xuseq(
+    inds=vs,
+    sortvars=usubjid visitnum,
+    prefix=vs,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing prefix | Set domain variable or specify prefix parameter |
+| Sort variable not found | Verify all sort variables exist in dataset |
+| Duplicate sequences | Review sort criteria for uniqueness |
+
+## Notes and Limitations
+- Sequence numbers restart at 1 for each unique USUBJID
+- Sort order must include USUBJID
+- Prefix must follow naming conventions
+- Debug mode retains __tmp_n variable
+- Modifies input dataset in place
+- Sort variables determine sequence grouping
+- Assumes USUBJID is present in dataset
+
+## Related Macros
+- SDTM/ADaM sequence generation macros
+- Dataset sorting utilities
+- Variable creation tools
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 14JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xusplit.md
+++ b/man/global/xusplit.md
@@ -94,10 +94,10 @@ Creates a dataset containing:
 - All split variables have same length
 - Missing values handled appropriately
 
-## Related Macros
-- Text processing macros
-- Variable management utilities
-- Clinical data standardization tools
+## See Also
+- [`%xusupp`](/man/global/xusupp.md): Supplemental qualifier creation
+- [`%xumrgcs`](/man/global/xumrgcs.md): Dataset merging utility
+- [`%xusave`](/man/global/xusave.md): Dataset saving utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xusplit.md
+++ b/man/global/xusplit.md
@@ -1,0 +1,105 @@
+# %xusplit - Text Variable Splitting Utility
+
+## Overview
+The `%xusplit` macro splits long text variables into multiple shorter sub-variables while preserving word boundaries. It's particularly useful for handling long text fields that need to be split across multiple columns while maintaining readability and preventing word truncation.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 15JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Name of the input dataset |
+| invar | Yes | - | Name of the input variable to split |
+| outds | No | &inds | Name of the output dataset |
+| prefix | No | &invar | Prefix for the output variable names |
+| len | No | 200 | Length of the output variables |
+| debug | No | N | Whether to retain temporary datasets (Y/N) |
+
+## Return Values/Output
+Creates a dataset containing:
+- Original dataset variables
+- Split text variables named:
+  - [prefix] (original variable)
+  - [prefix]1 to [prefix]N (additional segments)
+- Each split variable limited to specified length
+- Words kept intact (not truncated)
+- Empty split variables for short text
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Checks for non-empty values
+
+2. Text Processing:
+   - Creates observation order tracking
+   - Removes extra spaces with COMPBL
+   - Splits text at word boundaries
+   - Ensures splits don't exceed length limit
+   - Preserves word integrity
+
+3. Variable Creation:
+   - Transposes split segments into variables
+   - Determines required number of variables
+   - Applies consistent length to all segments
+   - Merges results with original dataset
+
+## Examples
+
+### Basic Usage
+```sas
+%xusplit(co, coval);
+```
+
+### Custom Output and Prefix
+```sas
+%xusplit(
+    inds=dv1,
+    invar=term,
+    outds=dv,
+    prefix=dvterm
+);
+```
+
+### Specified Length with Debug
+```sas
+%xusplit(
+    inds=trt_final,
+    invar=col3,
+    len=100,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing words | Increase len parameter |
+| Too many variables | Increase len to reduce splits |
+| Variable name conflicts | Use unique prefix |
+
+## Notes and Limitations
+- Maximum length for split variables is 32767
+- Original variable length is set to len parameter
+- Empty strings are preserved in output
+- Word boundaries are preserved
+- Extra spaces are removed
+- Debug mode retains intermediate datasets
+- All split variables have same length
+- Missing values handled appropriately
+
+## Related Macros
+- Text processing macros
+- Variable management utilities
+- Clinical data standardization tools
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 15JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xusupp.md
+++ b/man/global/xusupp.md
@@ -1,0 +1,120 @@
+# %xusupp - SDTM Supplemental Qualifier Domain Creation Utility
+
+## Overview
+The `%xusupp` macro creates and manages SDTM supplemental qualifier (SUPP--) domains by adding variables that don't fit into the parent domain's standard structure. It handles the creation and appending of supplemental records while maintaining SDTM standards and managing variable relationships between parent and supplemental domains.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 18JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- Required global variable:
+  - domain: Parent domain identifier (e.g., 'DM' for Demographics)
+- Required datasets:
+  - EMPTY_SUPP[domain]: Empty supplemental qualifier template
+  - Parent domain dataset
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Name of the input dataset |
+| invar | Yes | - | Name of the variable to add to SUPP-- domain |
+| idvar | No | [domain]seq* | Name of the identifier variable (*except for DM domain) |
+| qlabel | No | Variable label | Text to display in QLABEL variable |
+| qorig | No | - | Text to display in QORIG variable |
+| qeval | No | - | Text to display in QEVAL variable |
+| debug | No | N | Whether to retain temporary datasets (Y/N) |
+
+## Return Values/Output
+Creates or updates SUPP[domain] dataset containing:
+- Standard SDTM supplemental qualifier structure
+- Required variables:
+  - STUDYID, RDOMAIN, USUBJID
+  - IDVAR/IDVARVAL (when applicable)
+  - QNAM, QLABEL, QVAL
+  - QORIG, QEVAL
+- Sorted and de-duplicated records
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Validates domain variable existence
+   - Handles special DM domain case
+   - Determines appropriate identifier variable
+
+2. Data Processing:
+   - Sorts input data by key variables
+   - Transposes supplemental data
+   - Determines variable types
+   - Handles labels appropriately
+
+3. Output Generation:
+   - Creates SUPP-- records
+   - Appends to existing SUPP-- domain
+   - Removes duplicates
+   - Maintains SDTM standards
+
+## Examples
+
+### Basic Usage for Demographics
+```sas
+%let domain = DM;
+%xusupp(
+    inds=dm,
+    invar=RACEOTH,
+    qlabel=%str(Race, Other),
+    qorig=CRF
+);
+```
+
+### Custom Identifier Variable
+```sas
+%let domain = AE;
+%xusupp(
+    inds=ae,
+    invar=AEACNOTH,
+    idvar=AESEQ,
+    qlabel=Other Action Taken
+);
+```
+
+### Debug Mode
+```sas
+%let domain = VS;
+%xusupp(
+    inds=vs,
+    invar=VSPOS,
+    qorig=CRF,
+    qeval=INVESTIGATOR,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing domain variable | Set global domain variable before call |
+| Duplicate records | Check input data uniqueness |
+| Missing labels | Specify qlabel or add variable labels |
+
+## Notes and Limitations
+- Requires pre-existing empty SUPP domain template
+- DM domain ignores idvar parameter
+- Non-DM domains use [domain]seq by default
+- Automatically handles numeric/character IDs
+- Appends to existing SUPP-- datasets
+- De-duplicates final dataset
+- Variable labels used for QLABEL if not specified
+- Debug mode retains intermediate datasets
+
+## Related Macros
+- SDTM domain creation macros
+- Data standardization utilities
+- Variable management tools
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 18JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xusupp.md
+++ b/man/global/xusupp.md
@@ -98,6 +98,15 @@ Creates or updates SUPP[domain] dataset containing:
 | Missing domain variable | Set global domain variable before call |
 | Duplicate records | Check input data uniqueness |
 | Missing labels | Specify qlabel or add variable labels |
+| ERROR: Required operator not found in expression: &qlabel. ^= even though it is provided | Make sure "(", ")" are "escaped" with escapechar; </br> see example below |
+
+```sas
+/* For example this will trigger error */
+%xusupp(&domain., mlcho, idvar=mlseq, qlabel=%str(Carbohydrates (g)), qorig=CRF);
+
+/* Use this instead */
+%xusupp(&domain., mlcho, idvar=mlseq, qlabel=%str(Carbohydrates %(g%)), qorig=CRF); |
+```
 
 ## Notes and Limitations
 - Requires pre-existing empty SUPP domain template

--- a/man/global/xusupp.md
+++ b/man/global/xusupp.md
@@ -109,10 +109,10 @@ Creates or updates SUPP[domain] dataset containing:
 - Variable labels used for QLABEL if not specified
 - Debug mode retains intermediate datasets
 
-## Related Macros
-- SDTM domain creation macros
-- Data standardization utilities
-- Variable management tools
+## See Also
+- [`%xumrgcs`](/man/global/xumrgcs.md): Merge SUPP and CO datasets
+- [`%xusplit`](/man/global/xusplit.md): Text variable splitting utility
+- [`%xuload`](/man/global/xuload.md): Dataset loading utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xuvisit.md
+++ b/man/global/xuvisit.md
@@ -1,0 +1,104 @@
+# %xuvisit - SDTM Visit and Visit Number Derivation Utility
+
+## Overview
+The `%xuvisit` macro derives VISIT and VISITNUM variables for SDTM datasets using Trial Visits (TV) and Subject Visits (SV) domains as references. It handles both scheduled and unscheduled visits, ensuring proper visit numbering and naming according to SDTM standards.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 19JUL2022
+- **Author(s)**: Atorus Research
+
+## Dependencies
+- SAS version: SAS 9.4 V9
+- Required macros:
+  - xuload.sas - For loading reference domains
+- Required datasets:
+  - TV domain in SDTM library
+  - SV domain in SDTM library
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Name of the input dataset |
+| dtcdate | Yes | - | Name of the date variable for visit timing |
+| outds | No | &inds | Name of the output dataset |
+| debug | No | N | Whether to retain temporary datasets (Y/N) |
+
+## Return Values/Output
+Creates a dataset containing:
+- All variables from input dataset
+- Derived VISIT variable:
+  - From TV for scheduled visits
+  - From SV for unscheduled visits
+- Derived VISITNUM variable:
+  - Numeric visit identifier
+  - Matches TV/SV reference data
+  - Properly sequenced for unscheduled visits
+
+## Processing Details
+1. Input Validation:
+   - Verifies required parameters
+   - Checks for non-empty values
+
+2. Reference Data Processing:
+   - Loads TV and SV domains
+   - De-duplicates visit information
+   - Prepares unscheduled visit data
+
+3. Visit Assignment:
+   - Merges scheduled visits from TV
+   - Identifies unscheduled visits
+   - Assigns visit numbers and names
+   - Handles date-based visit timing
+
+## Examples
+
+### Basic Usage
+```sas
+%xuvisit(vs, vsdtc);
+```
+
+### Custom Output Dataset
+```sas
+%xuvisit(
+    inds=ae,
+    dtcdate=aestdtc,
+    outds=ae_visit
+);
+```
+
+### Debug Mode
+```sas
+%xuvisit(
+    inds=lb,
+    dtcdate=lbdtc,
+    debug=Y
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing TV/SV data | Ensure reference domains are in SDTM library |
+| Unmatched visits | Check visit naming consistency |
+| Date misalignment | Verify date variable format |
+
+## Notes and Limitations
+- Requires TV and SV domains in SDTM library
+- Unscheduled visits identified by "UNS" (case-insensitive)
+- Uses date substring (first 10 characters) for timing
+- Preserves original dataset structure
+- Debug mode retains intermediate datasets
+- Assumes consistent visit naming across domains
+- Handles both scheduled and unscheduled visits
+- Maintains SDTM compliance
+
+## Related Macros
+- SDTM timing variables macros
+- Visit and date handling utilities
+- Data standardization tools
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 19JUL2022 | Atorus Research | Initial version | 

--- a/man/global/xuvisit.md
+++ b/man/global/xuvisit.md
@@ -93,10 +93,10 @@ Creates a dataset containing:
 - Handles both scheduled and unscheduled visits
 - Maintains SDTM compliance
 
-## Related Macros
-- SDTM timing variables macros
-- Visit and date handling utilities
-- Data standardization tools
+## See Also
+- [`%xuseq`](/man/global/xuseq.md): Sequence number generation
+- [`%xuload`](/man/global/xuload.md): Dataset loading utility
+- [`%xusave`](/man/global/xusave.md): Dataset saving utility
 
 ## Change Log
 | Version | Date | Author | Changes |

--- a/man/global/xuvisit.md
+++ b/man/global/xuvisit.md
@@ -61,9 +61,9 @@ Creates a dataset containing:
 ### Custom Output Dataset
 ```sas
 %xuvisit(
-    inds=ae,
-    dtcdate=aestdtc,
-    outds=ae_visit
+    inds=vs,
+    dtcdate=vsdtc,
+    outds=vs_visit
 );
 ```
 

--- a/man/study_specific/jdtflstyle.md
+++ b/man/study_specific/jdtflstyle.md
@@ -110,8 +110,8 @@ The `%jdtflstyle` macro creates a style template for study PDF/RTF outputs. It o
    - Uses standard directory separators
    - Assumes specific naming conventions
 
-## Related Macros
-- `%kutitles`: Title and footnote management
+## See Also
+- [`%kutitles`](/man/study_specific/kutitles.md): Title and footnote management
 - Other TFL formatting macros
 
 ## Change Log

--- a/man/study_specific/jdtflstyle.md
+++ b/man/study_specific/jdtflstyle.md
@@ -1,0 +1,122 @@
+# %jdtflstyle
+
+## Overview
+The `%jdtflstyle` macro creates a style template for study PDF/RTF outputs. It opens ODS PDF/RTF destination, creates output files with specified formatting, and generates global macro variables containing timestamps. The macro implements custom styles based on SAS ODS style templates, markup, and tagsets.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 05MAY2021
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Global Variables:
+  - `__root`: Root directory path (created automatically by xuprogpath.sas)
+  - `__clnt_I`: Client identifier (created automatically by xuprogpath.sas)
+  - `__comp`: Compound identifier (created automatically by xuprogpath.sas)
+  - `__prot`: Protocol identifier (created automatically by xuprogpath.sas)
+  - `__subfolders_I`: Subfolder structure (created automatically by xuprogpath.sas)
+  - `__task`: Task identifier (created automatically by xuprogpath.sas)
+  - `__level`: Development level (created automatically by xuprogpath.sas)
+  - `__side_I`: Production side (created automatically by xuprogpath.sas)
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| filename | Yes | - | Name of the output file |
+| filepath | No | `&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&__side_I.&II.tfl` | File save path |
+| type | No | RTF | File extension (RTF/PDF) |
+| lmarg | No | 1in | Left margin size |
+| rmarg | No | 1in | Right margin size |
+| tmarg | No | 0.5in | Top margin size |
+| bmarg | No | 1in | Bottom margin size |
+| escapechar | No | $ | Escape character for ODS |
+
+## Return Values/Output
+- Creates output file:
+  - `[filename].rtf` or `[filename].pdf` in specified filepath
+- Creates global macro variables:
+  - `timestamp`: Current datetime in E8601DT16. format
+  - `tmstmp_date`: Date portion of timestamp
+  - `tmstmp_time`: Time portion of timestamp
+- Applies custom style template (glst1) with:
+  - Courier font family
+  - 9pt font size
+  - Specific table, header, and title formatting
+
+## Processing Details
+1. Parameter validation:
+   - Checks for empty required parameters
+   - Validates file type (RTF/PDF)
+   - Verifies path components
+
+2. Style template creation:
+   - Defines custom style (glst1)
+   - Sets font properties
+   - Configures table formatting
+   - Establishes header/footer styles
+
+3. Output generation:
+   - Creates timestamp variables
+   - Sets page orientation and margins
+   - Opens appropriate ODS destination
+   - Applies style template
+
+## Examples
+```sas
+/* Basic usage - create RTF output */
+%jdtflstyle(T_10_1_1);
+
+/* Create PDF with custom bottom margin */
+%jdtflstyle(F_15_1_2, 
+           type=PDF,
+           bmarg=0.8in);
+
+/* Specify custom filepath and escape character */
+%jdtflstyle(T_14_2_1,
+           filepath=/path/to/output,
+           escapechar=~);
+```
+
+## Common Issues and Solutions
+1. **Invalid File Type**
+   - Error: "parameter type should be RTF or PDF"
+   - Solution: Specify either RTF or PDF (case-insensitive)
+
+2. **Missing Parameters**
+   - Error: "[parameter] is required parameter and should not be NULL"
+   - Solution: Provide all required parameters
+
+3. **Path Issues**
+   - Issue: File not created in expected location
+   - Solution: Verify global variables for path construction
+
+## Notes and Limitations
+1. Style template specifications:
+   - Fixed font family (Courier)
+   - Fixed font size (9pt)
+   - Predefined table formatting
+   - Standard header/footer styling
+
+2. Output settings:
+   - Landscape orientation
+   - ACTXIMG device
+   - No automatic date/number
+   - No automatic titles/footnotes
+
+3. Global variable dependencies:
+   - Requires specific project structure
+   - Uses standard directory separators
+   - Assumes specific naming conventions
+
+## Related Macros
+- `%kutitles`: Title and footnote management
+- Other TFL formatting macros
+
+## Change Log
+### Version 1.0 (05MAY2021)
+- Initial release
+- Basic style template functionality
+- RTF/PDF output support
+- Timestamp variable creation 

--- a/man/study_specific/kdident.md
+++ b/man/study_specific/kdident.md
@@ -1,0 +1,109 @@
+# %kdident
+
+## Overview
+The `%kdident` macro is designed to beautifully split character variables for output in tables and listings. It intelligently breaks long text strings into multiple lines while maintaining readability and formatting, using specified maximum line lengths and custom formatting characters.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 21OCT2021
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| invar | Yes | - | Name of the input variable to be split |
+| maxln | Yes | - | Maximum number of characters allowed per line |
+| outvar | No | `&invar._new` | Name of the output variable |
+| tabchar | No | `$ $ $ ` | Tabulation characters used to pad newlines |
+| newlchar | No | `$n` | Newline character |
+| debug | No | N | Flag to retain temporary variables |
+
+## Return Values/Output
+- Creates a new variable (`outvar`) containing:
+  - Original text split into multiple lines
+  - Lines padded with specified tabulation characters
+  - Newline characters at break points
+- Maximum length of output variable: 10,000 characters
+- When debug=Y, retains temporary variables:
+  - `__tmp_[invar]l1-__tmp_[invar]l1000`: Array storing newline positions
+
+## Processing Details
+1. Parameter validation:
+   - Checks for required parameters
+   - Verifies parameter values are not empty
+   - Warns if input variable length exceeds 10,000
+
+2. Text processing:
+   - Initializes output variable with first word
+   - Processes remaining words sequentially
+   - Calculates current line length
+   - Determines line break positions
+
+3. Line breaking logic:
+   - Adds new line if next word exceeds maximum length
+   - Maintains word boundaries
+   - Applies tabulation at line breaks
+   - Preserves original spacing within limits
+
+## Examples
+```sas
+/* Basic usage - split AEBODSYS with 17-character limit */
+%kdident(aebodsys, 17);
+
+/* Custom output variable name and no tabulation */
+%kdident(lbcomm1, 32,
+         outvar=col10,
+         tabchar=%str());
+
+/* Custom newline character and debug mode */
+%kdident(cmtrt, 25,
+         newlchar=%str(#),
+         debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Long Input Text**
+   - Warning: "input variable length is more significant than 10000"
+   - Solution: Consider breaking input into smaller chunks
+
+2. **Missing Parameters**
+   - Error: "[parameter] is required parameter and should not be NULL"
+   - Solution: Provide all required parameters
+
+3. **Formatting Issues**
+   - Issue: Unexpected line breaks
+   - Solution: Adjust maxln parameter or tabchar spacing
+
+## Notes and Limitations
+1. Text processing:
+   - Maximum input length: 10,000 characters
+   - Preserves word boundaries
+   - Maintains original spacing where possible
+   - Uses space as word delimiter
+
+2. Output formatting:
+   - Line breaks occur at word boundaries
+   - Tabulation applied after each break
+   - Consistent indentation for wrapped lines
+   - Original text preserved within constraints
+
+3. Performance considerations:
+   - Creates temporary array variables
+   - Processes text word by word
+   - Memory usage proportional to text length
+
+## Related Macros
+- `%jdtflstyle`: Table styling and formatting
+- `%kutitles`: Title and footnote management
+- Other text formatting macros
+
+## Change Log
+### Version 1.0 (21OCT2021)
+- Initial release
+- Basic text splitting functionality
+- Custom formatting options
+- Debug mode implementation 

--- a/man/study_specific/kdident.md
+++ b/man/study_specific/kdident.md
@@ -96,10 +96,10 @@ The `%kdident` macro is designed to beautifully split character variables for ou
    - Processes text word by word
    - Memory usage proportional to text length
 
-## Related Macros
-- `%jdtflstyle`: Table styling and formatting
-- `%kutitles`: Title and footnote management
-- Other text formatting macros
+## See Also
+- [`%jdtflstyle`](/man/study_specific/jdtflstyle.md): Table styling and formatting
+- [`%kutitles`](/man/study_specific/kutitles.md): Title and footnote management
+- [`%kplotrtf`](/man/study_specific/kplotrtf.md): RTF output formatting
 
 ## Change Log
 ### Version 1.0 (21OCT2021)

--- a/man/study_specific/kqtlfcomp.md
+++ b/man/study_specific/kqtlfcomp.md
@@ -1,0 +1,135 @@
+# %kqtlfcomp
+
+## Overview
+The `%kqtlfcomp` macro performs comprehensive comparisons between production and QC versions of TLF (Tables, Listings, and Figures) datasets. It provides extensive customization options for handling formatting differences, variable attributes, and comparison criteria, making it particularly useful for clinical trial reporting quality control processes.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 09SEP2021
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| output | Yes | - | Output dataset name to compare |
+| prod_lib | No | tfl | Production library name |
+| qc_lib | No | vtfl | QC library name |
+| qc_output | No | - | QC dataset name (if different from production) |
+| where | No | 1 | WHERE clause for filtering comparison |
+| prod_drop | No | - | Variables to drop from production dataset |
+| dropchecked | No | N | Flag indicating QC review of dropped variables |
+| ignspl | No | Y | Ignore split characters in comparison |
+| chrspl | No | \| | Split character to ignore |
+| ignln | No | Y | Ignore variable lengths |
+| ignspc | No | N | Ignore spacing differences |
+| ignlbl | No | Y | Ignore variable labels |
+| ignfor | No | Y | Ignore variable formats |
+| ignifor | No | Y | Ignore variable informats |
+| compress | No | N | Remove all spaces before comparing |
+| crit | No | - | PROC COMPARE criteria specification |
+| debug | No | N | Retain temporary datasets for debugging |
+
+## Return Values/Output
+- Creates comparison datasets:
+  - `prod_[output]`: Production dataset with applied modifications
+  - `qc_[output]`: QC dataset with applied modifications
+  - `dif_[output]`: Differences between datasets
+- Log messages indicating:
+  - Missing or invalid parameters
+  - Dataset existence checks
+  - Variables dropped from comparison
+  - Comparison results and differences
+
+## Processing Details
+1. Parameter validation:
+   - Checks required parameters
+   - Validates Y/N parameters
+   - Verifies dataset existence
+   - Confirms library accessibility
+
+2. Dataset preparation:
+   - Applies specified filters
+   - Drops requested variables
+   - Handles variable attributes
+   - Processes formatting differences
+
+3. Text handling:
+   - Manages RTF instructions
+   - Processes split characters
+   - Handles spacing differences
+   - Applies compression if requested
+
+4. Comparison execution:
+   - Performs dataset comparison
+   - Generates difference reports
+   - Manages temporary datasets
+   - Handles debug output
+
+## Examples
+```sas
+/* Basic comparison */
+%kqtlfcomp(output=t_14_3_1_1);
+
+/* Detailed comparison with custom settings */
+%kqtlfcomp(output=t_14_3_1_1,
+           prod_drop=rowlbl,
+           dropchecked=Y,
+           prod_lib=tfl,
+           qc_lib=work,
+           where=%str(lbcat="HEMATOLOGY"),
+           ignspl=Y,
+           chrspl=|,
+           ignln=N,
+           compress=Y);
+
+/* Debug mode with custom criteria */
+%kqtlfcomp(output=t_14_3_1_1,
+           crit=0.00001,
+           debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Dataset Not Found**
+   - Error: "production/qc file did not exist"
+   - Solution: Verify library and dataset names
+
+2. **Dropped Variables**
+   - Warning: "vars dropped from the production dataset"
+   - Solution: Review and set dropchecked=Y if correct
+
+3. **Multiple QC Datasets**
+   - Error: "qc library did not contain a clear dataset"
+   - Solution: Specify exact QC dataset name
+
+## Notes and Limitations
+1. Dataset handling:
+   - Maximum output name length: 27 characters
+   - Automatic dataset cleanup
+   - Case-insensitive dataset names
+   - Library-specific processing
+
+2. Comparison options:
+   - Multiple ignore flags available
+   - RTF formatting handling
+   - Split character processing
+   - Space compression options
+
+3. Performance considerations:
+   - Memory usage for large datasets
+   - Temporary dataset creation
+   - Debug mode impact
+
+## Related Macros
+- `%kqucomp`: General dataset comparison
+- Other QC and validation macros
+
+## Change Log
+### Version 1.0 (09SEP2021)
+- Initial release
+- Comprehensive comparison functionality
+- Multiple formatting options
+- Debug mode support 

--- a/man/study_specific/kqtlfcomp.md
+++ b/man/study_specific/kqtlfcomp.md
@@ -123,9 +123,10 @@ The `%kqtlfcomp` macro performs comprehensive comparisons between production and
    - Temporary dataset creation
    - Debug mode impact
 
-## Related Macros
-- `%kqucomp`: General dataset comparison
-- Other QC and validation macros
+## See Also
+- [`%kqucomp`](/man/study_specific/kqucomp.md): General dataset comparison
+- [`%xuct`](/man/global/xuct.md): Controlled terminology validation
+- [`%xumrgcs`](/man/global/xumrgcs.md): Dataset merging utility
 
 ## Change Log
 ### Version 1.0 (09SEP2021)

--- a/man/study_specific/kqucomp.md
+++ b/man/study_specific/kqucomp.md
@@ -68,8 +68,8 @@ The `%kqucomp` macro performs dataset comparisons between production and QC vers
 
 ## Examples
 ```sas
-/* Basic comparison of DM domain */
-%kqucomp(base=DM, prod_lib=sdtm, supp=Y, com=Y);
+/* Basic comparison of LB domain */
+%kqucomp(base=LB, prod_lib=sdtm, supp=Y, com=Y);
 
 /* Custom comparison with specific criteria */
 %kqucomp(base=ADSL,

--- a/man/study_specific/kqucomp.md
+++ b/man/study_specific/kqucomp.md
@@ -115,9 +115,9 @@ The `%kqucomp` macro performs dataset comparisons between production and QC vers
    - Separate comparisons for each component
    - Standard PROC COMPARE output
 
-## Related Macros
-- `%kqtlfcomp`: TLF dataset comparison
-- `%xusupp`: Supplemental qualifier creation
+## See Also
+- [`%kqtlfcomp`](/man/study_specific/kqtlfcomp.md): TLF dataset comparison
+- [`%xusupp`](/man/global/xusupp.md): Supplemental qualifier creation
 - Other validation macros
 
 ## Change Log

--- a/man/study_specific/kqucomp.md
+++ b/man/study_specific/kqucomp.md
@@ -1,0 +1,128 @@
+# %kqucomp
+
+## Overview
+The `%kqucomp` macro performs dataset comparisons between production and QC versions of clinical trial datasets. It supports comparison of main datasets along with their associated supplemental qualifiers (SUPP--) and comments datasets, making it particularly useful for SDTM and ADaM dataset validation.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 20AUG2021
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Global Variables:
+  - `domain`: Current domain being processed
+  - `[domain]sortstring`: Sort variables for the domain (created automatically by xtorder.sas)
+- No macro dependencies
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| base | No | `&domain` | Base dataset name for comparison |
+| qc | No | qc | Prefix for QC dataset name |
+| id | No | `&&&domain.sortstring` | List of ID variables for comparison |
+| prod_lib | No | sdtm | Production library name |
+| qc_lib | No | work | QC library name |
+| crit | No | - | PROC COMPARE criterion specification |
+| supp | No | N | Flag to compare supplemental qualifier datasets |
+| com | No | N | Flag to compare comments datasets |
+
+## Return Values/Output
+- Generates PROC CONTENTS output for:
+  - Base dataset
+  - SUPP-- dataset (if supp=Y)
+  - Comments dataset (if com=Y)
+- Produces PROC COMPARE results showing:
+  - Variable differences
+  - Value differences
+  - Attribute differences
+  - Observation differences
+- Log messages indicating:
+  - Missing parameters
+  - Dataset existence
+  - Comparison results
+
+## Processing Details
+1. Parameter validation:
+   - Checks required parameters
+   - Verifies parameter values
+   - Validates dataset existence
+
+2. Main dataset comparison:
+   - Executes PROC CONTENTS
+   - Performs PROC COMPARE
+   - Uses specified ID variables
+   - Applies comparison criteria
+
+3. Supplemental qualifier comparison (if supp=Y):
+   - Checks for SUPP-- datasets
+   - Verifies observation counts
+   - Compares using standard SUPP keys
+   - Processes only if data exists
+
+4. Comments dataset comparison (if com=Y):
+   - Checks for _comm datasets
+   - Verifies observation counts
+   - Compares using standard keys
+   - Processes only if data exists
+
+## Examples
+```sas
+/* Basic comparison of DM domain */
+%kqucomp(base=DM, prod_lib=sdtm, supp=Y, com=Y);
+
+/* Custom comparison with specific criteria */
+%kqucomp(base=ADSL,
+         qc=validation,
+         id=studyid usubjid,
+         prod_lib=adam,
+         qc_lib=valid,
+         crit=0.00001);
+
+/* Compare only main dataset with default settings */
+%kqucomp(base=VS,
+         prod_lib=sdtm);
+```
+
+## Common Issues and Solutions
+1. **Missing Parameters**
+   - Error: "[parameter] is required parameter and should not be NULL"
+   - Solution: Provide all required parameters
+
+2. **Empty Datasets**
+   - Issue: No comparison results for SUPP/comments
+   - Solution: Verify datasets contain observations
+
+3. **ID Variables**
+   - Issue: Unexpected comparison results
+   - Solution: Verify correct ID variables specified
+
+## Notes and Limitations
+1. Dataset handling:
+   - Automatic SUPP-- dataset detection
+   - Standard SDTM/ADaM naming conventions
+   - Empty dataset handling
+   - Library-specific processing
+
+2. Comparison features:
+   - Full dataset comparison
+   - Supplemental qualifier support
+   - Comments dataset support
+   - Flexible ID variable specification
+
+3. Performance considerations:
+   - Processes only non-empty datasets
+   - Separate comparisons for each component
+   - Standard PROC COMPARE output
+
+## Related Macros
+- `%kqtlfcomp`: TLF dataset comparison
+- `%xusupp`: Supplemental qualifier creation
+- Other validation macros
+
+## Change Log
+### Version 1.0 (20AUG2021)
+- Initial release
+- Basic comparison functionality
+- SUPP-- dataset support
+- Comments dataset support 

--- a/man/study_specific/kudlen.md
+++ b/man/study_specific/kudlen.md
@@ -1,0 +1,118 @@
+# %kudlen
+
+## Overview
+The `%kudlen` macro optimizes variable lengths in a dataset by adjusting character variable lengths to match the maximum length of their actual values. This helps reduce memory usage and improve efficiency while preserving all data content, labels, and formats.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 20AUG2021
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Macros:
+  - `%xurnm`: Variable renaming utility
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| inds | Yes | - | Input dataset name |
+| outds | No | `&inds` | Output dataset name |
+| debug | No | N | Flag to retain temporary datasets |
+
+## Return Values/Output
+- Creates a new dataset with:
+  - Optimized character variable lengths
+  - Preserved variable attributes:
+    - Labels
+    - Formats
+    - Informats
+  - Unchanged numeric variables
+  - Original data values
+- Log messages indicating:
+  - Processing status
+  - Parameter validation
+  - Error conditions
+
+## Processing Details
+1. Parameter validation:
+   - Checks required parameters
+   - Verifies dataset existence
+   - Validates parameter values
+
+2. Metadata analysis:
+   - Extracts variable information
+   - Identifies character variables
+   - Preserves variable attributes
+   - Maintains variable order
+
+3. Length optimization:
+   - Calculates maximum length per variable
+   - Processes only character variables
+   - Maintains minimum length of 1
+   - Preserves numeric lengths
+
+4. Dataset recreation:
+   - Applies optimized lengths
+   - Restores variable attributes
+   - Maintains data integrity
+   - Cleans up temporary files
+
+## Examples
+```sas
+/* Basic usage - optimize current dataset */
+%kudlen(dm);
+
+/* Create new optimized dataset */
+%kudlen(ae,
+        outds=ae_opt);
+
+/* Debug mode for troubleshooting */
+%kudlen(lb,
+        outds=lb_opt,
+        debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Missing Parameters**
+   - Error: "[parameter] is required parameter and should not be NULL"
+   - Solution: Provide required parameters
+
+2. **Memory Issues**
+   - Issue: Large datasets with many variables
+   - Solution: Process in smaller chunks
+
+3. **Variable Attributes**
+   - Issue: Lost formats or labels
+   - Solution: Verify metadata preservation
+
+## Notes and Limitations
+1. Variable processing:
+   - Only optimizes character variables
+   - Preserves numeric variable lengths (8 bytes)
+   - Maintains minimum length of 1
+   - Retains original variable order
+
+2. Attribute handling:
+   - Preserves variable labels
+   - Maintains formats and informats
+   - Keeps variable names
+   - Retains metadata properties
+
+3. Performance considerations:
+   - Creates temporary datasets
+   - Memory usage during processing
+   - Multiple metadata operations
+   - Sequential processing
+
+## Related Macros
+- `%xurnm`: Variable renaming
+- `%xuload`: Dataset loading
+- Other data management macros
+
+## Change Log
+### Version 1.0 (20AUG2021)
+- Initial release
+- Basic length optimization
+- Attribute preservation
+- Debug mode support 

--- a/man/study_specific/kudlen.md
+++ b/man/study_specific/kudlen.md
@@ -105,9 +105,9 @@ The `%kudlen` macro optimizes variable lengths in a dataset by adjusting charact
    - Multiple metadata operations
    - Sequential processing
 
-## Related Macros
-- `%xurnm`: Variable renaming
-- `%xuload`: Dataset loading
+## See Also
+- [`%xurnm`](/man/global/xurnm.md): Variable renaming
+- [`%xuload`](/man/global/xuload.md): Dataset loading
 - Other data management macros
 
 ## Change Log

--- a/man/study_specific/kutitles.md
+++ b/man/study_specific/kutitles.md
@@ -1,0 +1,129 @@
+# %kutitles
+
+## Overview
+The `%kutitles` macro assigns titles to SAS outputs based on specifications from a TFL (Tables, Figures, and Listings) titles file. It manages global and program-specific titles, handles title justification, and automatically includes page numbers and timestamps in standard locations.
+
+## Version Information
+- Version: 1.0
+- Last Updated: 17SEP2022
+- Author: Atorus Research
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Files:
+  - `TFL_titles.csv` in specified filepath
+- Required Global Variables:
+  - `__root`: Root directory path (created automatically by xuprogpath.sas)
+  - `__clnt_I`: Client identifier (created automatically by xuprogpath.sas)
+  - `__comp`: Compound identifier (created automatically by xuprogpath.sas)
+  - `__prot`: Protocol identifier (created automatically by xuprogpath.sas)
+  - `__subfolders_I`: Subfolder structure (created automatically by xuprogpath.sas)
+  - `__task`: Task identifier (created automatically by xuprogpath.sas)
+  - `tmstmp_date`: Current date (created automatically by jdtflstyle.sas)
+  - `tmstmp_time`: Current time (created automatically by jdtflstyle.sas)
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| progname | Yes | - | Program name to search in TFL_titles.csv |
+| filepath | No | `&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.final&II.specs` | Path to TFL_titles.csv |
+| seq | No | 1 | Sequence number of output in TFL_titles.csv |
+| justify | No | c | Title alignment (l/c/r) |
+| escapechar | No | $ | ODS escape character |
+| debug | No | N | Flag to retain temporary datasets |
+
+## Return Values/Output
+- Sets up to 5 title lines:
+  - Title1: Left-justified title with right-justified page number
+  - Title2: Left-justified title with right-justified program name and timestamp
+  - Title3-5: Justified according to parameter setting
+- Log messages indicating:
+  - Missing parameters
+  - Missing titles file
+  - Multiple title entries
+  - Missing global titles
+
+## Processing Details
+1. Parameter validation:
+   - Checks required parameters
+   - Verifies TFL_titles.csv existence
+   - Validates parameter values
+
+2. Title preparation:
+   - Clears existing titles
+   - Imports titles file
+   - Checks for duplicate entries
+   - Processes global titles
+
+3. Title formatting:
+   - Handles quotation marks
+   - Applies justification
+   - Adds page numbers
+   - Includes timestamps
+
+4. Title assignment:
+   - Sets up to 5 title lines
+   - Applies specified formatting
+   - Manages missing titles
+   - Cleans up temporary data
+
+## Examples
+```sas
+/* Basic usage for single output */
+%kutitles(s_000_ae3, seq=1);
+
+/* Custom justification and filepath */
+%kutitles(l_000_dm,
+          filepath=/path/to/specs,
+          justify=l);
+
+/* Debug mode with custom escape character */
+%kutitles(t_14_3_1_1,
+          seq=2,
+          escapechar=~,
+          debug=Y);
+```
+
+## Common Issues and Solutions
+1. **Missing Titles File**
+   - Error: "TFL_titles.csv was not found"
+   - Solution: Verify file path and existence
+
+2. **Multiple Title Entries**
+   - Warning: "multiple rows present for [program]"
+   - Solution: Review and correct TFL_titles.csv
+
+3. **Missing Global Titles**
+   - Warning: "title1 and title2 were not resolved"
+   - Solution: Check GlobalTitle1/2 in TFL_titles.csv
+
+## Notes and Limitations
+1. Title structure:
+   - Maximum 5 title lines
+   - Standard header format
+   - Automatic page numbering
+   - Program identification
+
+2. File requirements:
+   - CSV format
+   - Specific column structure
+   - Global title definitions
+   - Program-specific entries
+
+3. Processing behavior:
+   - Clears existing titles
+   - Handles missing entries
+   - Preserves title order
+   - Manages special characters
+
+## Related Macros
+- `%jdtflstyle`: Output styling
+- `%kplotrtf`: RTF plot generation
+- Other TFL formatting macros
+
+## Change Log
+### Version 1.0 (17SEP2022)
+- Initial release
+- Basic title management
+- Global title support
+- Automatic page numbering 

--- a/man/study_specific/kutitles.md
+++ b/man/study_specific/kutitles.md
@@ -116,9 +116,9 @@ The `%kutitles` macro assigns titles to SAS outputs based on specifications from
    - Preserves title order
    - Manages special characters
 
-## Related Macros
-- `%jdtflstyle`: Output styling
-- `%kplotrtf`: RTF plot generation
+## See Also
+- [`%jdtflstyle`](/man/study_specific/jdtflstyle.md): Output styling
+- [`%kplotrtf`](/man/study_specific/kplotrtf.md): RTF plot generation
 - Other TFL formatting macros
 
 ## Change Log

--- a/man/study_specific/setup.md
+++ b/man/study_specific/setup.md
@@ -6,7 +6,7 @@ The `%setup` macro initializes the study environment by setting up global variab
 ## Version Information
 - **Version**: 1.0
 - **Last Updated**: 18FEB2021
-- **Author(s)**: Rostyslav Didenko
+- **Author(s)**: Atorus Research
 
 ## Dependencies
 - SAS Version: SAS 9.4 V9
@@ -66,13 +66,14 @@ Production/Validation Libraries (when `__side` is defined):
 ### Automatic Usage
 ```sas
 /* The macro is called automatically by %xumprint */
-%xumprint(program=myprogram.sas);
+%xumprint(route=YES);
 ```
 
 ### Manual Usage (if needed)
 ```sas
 /* First call xuprogpath to set required globals */
 %xuprogpath;
+
 /* Then run setup */
 %setup;
 ```

--- a/man/study_specific/setup.md
+++ b/man/study_specific/setup.md
@@ -1,0 +1,110 @@
+# %setup - Study Environment Setup Utility
+
+## Overview
+The `%setup` macro initializes the study environment by setting up global variables for directory paths and creating library references. It processes directory structure information to establish paths for client, protocol, and task-specific locations, and creates standardized library references for study data.
+
+## Version Information
+- **Version**: 1.0
+- **Last Updated**: 18FEB2021
+- **Author(s)**: Rostyslav Didenko
+
+## Dependencies
+- SAS Version: SAS 9.4 V9
+- Required Macros:
+  - `%xuprogpath`: For determining program execution path and setting initial global variables
+- No external files/datasets required
+
+## Parameters
+This macro has no parameters as it is designed to run automatically within the `%xumprint` macro.
+
+## Return Values/Output
+Creates the following:
+
+### Global Variables
+- `__clnt_I`: Client folder path component with separator
+- `__subfolders_I`: Subfolder path components with separators
+- `__side_I`: Side folder path component with separator
+
+### Library References
+Standard Libraries:
+- `specs`: Specifications folder
+- `crf`: CRF data
+- `external`: External data
+- `dict`: Dictionary/reference data
+- `rawmisc`: Miscellaneous raw data
+- `raw`: Concatenation of crf, external, dict, and rawmisc
+
+Production/Validation Libraries (when `__side` is defined):
+- Production:
+  - `sdtm`: SDTM datasets
+  - `adam`: ADaM datasets
+  - `tfl`: Tables, Figures, and Listings
+  - `misc`: Miscellaneous files
+- Validation:
+  - `vsdtm`: Validation SDTM datasets
+  - `vadam`: Validation ADaM datasets
+  - `vtfl`: Validation TFLs
+  - `vmisc`: Validation miscellaneous files
+
+## Processing Details
+1. Initial Setup:
+   - Calls `%xuprogpath` to determine program path and set initial variables
+   - Creates conditional setup macro for directory structure processing
+
+2. Directory Structure Processing:
+   - Processes `__clnt` variable to create `__clnt_I`
+   - Processes `__subfolders` variable to create `__subfolders_I`
+   - Processes `__side` variable to create `__side_I`
+
+3. Library Assignment:
+   - Creates standard library references for raw data
+   - Conditionally creates production/validation libraries based on `__side` value
+   - Sets up SASAUTOS path for macro libraries
+
+## Examples
+
+### Automatic Usage
+```sas
+/* The macro is called automatically by %xumprint */
+%xumprint(program=myprogram.sas);
+```
+
+### Manual Usage (if needed)
+```sas
+/* First call xuprogpath to set required globals */
+%xuprogpath;
+/* Then run setup */
+%setup;
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Missing library paths | Verify directory structure matches expected pattern |
+| Invalid permissions | Check user access to specified directories |
+| Missing global variables | Ensure `%xuprogpath` is called before `%setup` |
+
+## Notes and Limitations
+1. Directory Structure:
+   - Assumes standard project directory structure
+   - Requires specific folder hierarchy for proper path resolution
+   - Handles both production/validation separated and combined structures
+
+2. Library References:
+   - Creates standard set of library references
+   - Adapts to presence/absence of validation directories
+   - All paths use OS-appropriate separators
+
+3. Usage Context:
+   - Designed for automatic execution within `%xumprint`
+   - Can be run standalone if needed
+   - Requires prior execution of `%xuprogpath`
+
+## See Also
+- [`%xuprogpath`](/man/global/xuprogpath.md): Program path resolution utility
+- [`%xumprint`](/man/global/xumprint.md): Program execution wrapper
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | 18FEB2021 | Rostyslav Didenko | Initial version | 

--- a/man/template.md
+++ b/man/template.md
@@ -64,7 +64,7 @@ Detailed description of:
 - Important note 2
 - Known limitations
 
-## Related Macros
+## See Also
 - Link to related macro 1
 - Link to related macro 2
 

--- a/man/template.md
+++ b/man/template.md
@@ -1,0 +1,75 @@
+# %macro_name - Macro Title
+
+## Overview
+Brief description of what the macro does and its primary purpose.
+
+## Version Information
+- **Version**: X.X
+- **Last Updated**: YYYY-MM-DD
+- **Author(s)**: Name(s)
+
+## Dependencies
+List of required:
+- SAS version
+- Other macros
+- External files/datasets
+- Special requirements
+
+## Parameters
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| PARAM1 | Yes/No | value | Detailed description |
+| PARAM2 | Yes/No | value | Detailed description |
+
+## Return Values/Output
+Description of:
+- Output datasets
+- Global variables set
+- Return codes
+- Log messages
+- Other outputs
+
+## Processing Details
+Detailed description of:
+1. Input validation and preprocessing
+2. Main processing steps
+3. Error handling
+4. Special cases and considerations
+
+## Examples
+
+### Basic Usage
+```sas
+%macro_name(param1=value1, param2=value2);
+```
+
+### Advanced Usage
+```sas
+/* Example with more complex parameters */
+%macro_name(
+    param1=value1,
+    param2=value2,
+    param3=value3
+);
+```
+
+## Common Issues and Solutions
+| Issue | Solution |
+|-------|----------|
+| Issue 1 | Solution description |
+| Issue 2 | Solution description |
+
+## Notes and Limitations
+- Important note 1
+- Important note 2
+- Known limitations
+
+## Related Macros
+- Link to related macro 1
+- Link to related macro 2
+
+## Change Log
+| Version | Date | Author | Changes |
+|---------|------|---------|---------|
+| 1.0 | YYYY-MM-DD | Name | Initial version |
+| 1.1 | YYYY-MM-DD | Name | Description of changes | 

--- a/sas/study_specific/setup.sas
+++ b/sas/study_specific/setup.sas
@@ -1,0 +1,103 @@
+/************************************************************************************
+* Program/Macro:             setup.sas
+* Protocol:                  
+* SAS Ver:                   SAS 9.4 V9
+* Author:                    Rostyslav Didenko
+* Date:                      18FEB2021
+* Program Title:             
+*
+* Description:               Setups global variables __root, __clnt_I, __comp, __prot, __subfolders_I,
+*							 __task, __level, __side_I using %xuprogpath macro. Creates libraries.
+* Remarks:                   This macro should be called automatically within %xumprint macro.
+* Input:                     N/A
+* Output:  					 N/A
+* 
+* Parameters:                N/A
+*                            
+* Sample Call:               N/A
+*
+* Assumptions:               
+* Revisions:                
+* Revision #	Programmer 	                   Date 	     	   Description of Change(s)
+* ----------    ----------------------         ------------        ---------------------------
+*
+************************************************************************************/
+
+%*Get program execution path and setup task/client related global macro variables.;
+%xuprogpath;
+
+%*Create __clnt_I, __subfolders_I, __side_I variables based on directory structure.;
+%macro cond_setup;
+
+	%global __clnt_I __subfolders_I __side_I;
+
+	%*If __clnt global variable from %xuprogpath is not null then __clnt_I is set to "/[client folder name]";
+	%if &__clnt ^= %then %do;
+		%let __clnt_I = &II.&__clnt;
+	%end;
+	%*If __clnt global variable from %xuprogpath is null then __clnt_I is set to null;
+	%else %do;
+		%let __clnt_I = ;
+	%end;
+
+	%*If __subfolders global variable from %xuprogpath is not null then __subfolders_I is set to "/[list of subfolder names]";
+	%if &__subfolders ^= %then %do;
+		%let __subfolders_I = &II.&__subfolders;
+	%end;
+	%*If __subfolders global variable from %xuprogpath is null then __subfolders_I is set to null;
+	%else %do;
+		%let __subfolders_I = ;
+	%end;
+
+	%*If __side global variable from %xuprogpath is not null then __side_I is set to "/[side folder name]";
+	%if &__side ^= %then %do;
+		%let __side_I = &II.&__side;
+	%end;
+	%*If __side global variable from %xuprogpath is null then __side_I is set to null;
+	%else %do;
+		%let __side_I = ;
+	%end;
+
+%mend cond_setup;
+
+%cond_setup;
+
+%*Set libraries.;
+%macro set_lib;
+
+	libname specs "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.final&II.specs";
+	libname crf "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.final&II.raw&II.crf";
+	libname external "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.final&II.raw&II.external";
+	libname dict "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.final&II.raw&II.dict";
+	libname rawmisc "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.final&II.raw&II.misc";
+	libname raw (crf, external, dict, rawmisc);
+
+	%*For direcrory that has prod/val separation.;
+	%if &__side ^= %then %do;
+		libname sdtm "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.prod&II.sdtm";
+		libname adam "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.prod&II.adam";
+		libname tfl "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.prod&II.tfl";
+		libname misc "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.prod&II.misc";
+
+		libname vsdtm "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.val&II.sdtm";
+		libname vadam "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.val&II.adam";
+		libname vtfl "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.val&II.tfl";
+		libname vmisc "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.val&II.misc";
+	%end;
+	
+	%*For direcrory that has not prod/val separation.;
+	%else %do;
+		libname sdtm "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.sdtm";
+		libname adam "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.adam";
+		libname tfl "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.tfl";
+		libname misc "&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&II.misc";
+	%end;
+
+%mend set_lib;
+
+%set_lib;
+
+%*Setup path to global and task-specific macros library.;
+options mautosource sasautos=("&__root.&__clnt_I.&II.&__comp.&II.&__prot.&__subfolders_I.&II.&__task.&II.&__level.&__side_I.&II.func",
+							  "&__root.&II.utils&II.func",
+                              sasautos);

--- a/sas/study_specific/setup.sas
+++ b/sas/study_specific/setup.sas
@@ -2,7 +2,7 @@
 * Program/Macro:             setup.sas
 * Protocol:                  
 * SAS Ver:                   SAS 9.4 V9
-* Author:                    Rostyslav Didenko
+* Author:                    Atorus Research
 * Date:                      18FEB2021
 * Program Title:             
 *


### PR DESCRIPTION
This adds comprehensive markdown documentation for a collection of global and study-specific SAS macros. The documentation includes:

- An overview of each macro's purpose
- Version and authorship information
- Dependency requirements
- Comprehensive parameter descriptions
- Usage examples
- Common issues and solutions
- Notes and limitations
- Related macros
- Change log